### PR TITLE
auto: Add CustomerService.count_by_status for dashboards

### DIFF
--- a/src/services/customer_service.py
+++ b/src/services/customer_service.py
@@ -201,3 +201,13 @@ class CustomerService:
             data={"imported": imported, "errors": errors},
             message=f"成功导入{imported}条客户记录"
         )
+
+    def count_by_status(self, tenant_id: int) -> Dict[CustomerStatus, int]:
+        """Return count of customers grouped by CustomerStatus for a given tenant."""
+        if tenant_id <= 0:
+            return {}
+        counts: Dict[CustomerStatus, int] = {}
+        for customer in self._customers.values():
+            if customer.tenant_id == tenant_id:
+                counts[customer.status] = counts.get(customer.status, 0) + 1
+        return counts

--- a/tests/unit/test_customer_service.py
+++ b/tests/unit/test_customer_service.py
@@ -3,6 +3,7 @@ Unit tests for CustomerService.
 """
 import pytest
 from src.services.customer_service import CustomerService
+from src.models.customer import CustomerStatus
 
 
 @pytest.fixture
@@ -118,6 +119,60 @@ class TestCustomerService:
         assert bool(result) is True
         # No inactive customers created
         assert len(result.data.items) == 0
+
+    def test_count_by_status_basic(self, customer_service):
+        """Test count_by_status returns correct counts per status for a tenant."""
+        customer_service.create_customer({
+            "name": "Lead 1", "email": "lead1@test.com", "owner_id": 1,
+            "status": "lead",
+        }, tenant_id=1)
+        customer_service.create_customer({
+            "name": "Active 1", "email": "active1@test.com", "owner_id": 1,
+            "status": "customer",
+        }, tenant_id=1)
+        customer_service.create_customer({
+            "name": "Inactive 1", "email": "inactive1@test.com", "owner_id": 1,
+            "status": "inactive",
+        }, tenant_id=1)
+
+        counts = customer_service.count_by_status(1)
+        assert counts == {
+            CustomerStatus.LEAD: 1,
+            CustomerStatus.CUSTOMER: 1,
+            CustomerStatus.INACTIVE: 1,
+        }
+
+    def test_count_by_status_multi_tenant(self, customer_service):
+        """Test count_by_status isolates counts per tenant."""
+        # Tenant 1: 2 customers
+        customer_service.create_customer({
+            "name": "T1 Customer", "email": "t1a@test.com", "owner_id": 1,
+            "status": "customer",
+        }, tenant_id=1)
+        customer_service.create_customer({
+            "name": "T1 Lead", "email": "t1l@test.com", "owner_id": 1,
+            "status": "lead",
+        }, tenant_id=1)
+        # Tenant 2: 1 customer
+        customer_service.create_customer({
+            "name": "T2 Customer", "email": "t2c@test.com", "owner_id": 2,
+            "status": "customer",
+        }, tenant_id=2)
+
+        counts_t1 = customer_service.count_by_status(1)
+        counts_t2 = customer_service.count_by_status(2)
+
+        assert counts_t1 == {CustomerStatus.CUSTOMER: 1, CustomerStatus.LEAD: 1}
+        assert counts_t2 == {CustomerStatus.CUSTOMER: 1}
+
+    def test_count_by_status_zero_tenant(self, customer_service):
+        """Test count_by_status returns empty dict for tenant_id <= 0."""
+        customer_service.create_customer({
+            "name": "Any Customer", "email": "any@test.com", "owner_id": 1,
+        }, tenant_id=1)
+
+        assert customer_service.count_by_status(0) == {}
+        assert customer_service.count_by_status(-1) == {}
 
     def test_list_customers_filter_by_owner(self, customer_service):
         """Test filtering customers by owner."""


### PR DESCRIPTION
**Automated implementation of `research-manual-count-by-status`**

- **task:** Add CustomerService.count_by_status for dashboards
- **priority:** medium · **kind:** refactor
- **estimate:** 15 min

**Plan steps**
- `src/services/customer_service.py`: Add method: `def count_by_status(self, tenant_id: int) -> Dict[CustomerStatus, int]:` — guard `if tenant_id <= 0: return {}`. Filter `self._customers.values()` by `tenant_id`, then use a Counter or manual dict to tally by `c.status`. Return `Dict[CustomerStatus, int]`. Ensure the import at the top includes `from typing import Dict` (already present) and `from collections import Counter` if used.
- `tests/unit/test_customer_service.py`: Add three test methods: (1) `test_count_by_status_basic` — create 3 customers for tenant_id=1 with statuses LEAD, ACTIVE, INACTIVE; assert `count_by_status(1)` returns `{CustomerStatus.LEAD: 1, CustomerStatus.ACTIVE: 1, CustomerStatus.INACTIVE: 1}`. (2) `test_count_by_status_multi_tenant` — same 3 for tenant 1, plus 2 customers for tenant 2; assert tenant 2's counts are isolated and tenant 1's are unchanged. (3) `test_count_by_status_zero_tenant` — call `count_by_status(0)` and assert `{}` is returned.

**Risks flagged by planner**
- CustomerStatus enum must have keys matching what create_customer sets by default (e.g. 'lead' -> LEAD, 'active' -> ACTIVE, 'inactive' -> INACTIVE) — verify against src/models/customer.py if any status-mapping ambiguity arises
- Dict[CustomerStatus, int] return type requires `from typing import Dict` import in customer_service.py (already imported)

**Verification run in worktree before push**
- pytest: ✅ unit suite green
- pre-commit hook: ✅ passed

Generated by `scripts/cron/pipeline.py implement`. This PR was not merged and will not auto-merge.