### PR TITLE
security: remove hardcoded Railway token; ignore shared-memory runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ build/
 railway-binary/
 railway-cli-4.36.1.tgz
 railway-cli-bin/
+shared-memory/logs/
+shared-memory/locks/
+shared-memory/results/
+shared-memory/reports/
+.worktrees/

--- a/deploy.js
+++ b/deploy.js
@@ -7,7 +7,11 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
-const TOKEN = '2dc2f4ae-4e33-4ec4-a715-474a16792c00';
+const TOKEN = process.env.RAILWAY_TOKEN;
+if (!TOKEN) {
+  console.error('RAILWAY_TOKEN environment variable is required');
+  process.exit(1);
+}
 const REPO = 'yihua-zhuo/agent-job';
 
 function apiRequest(method, path, body = null) {

--- a/railway-deploy.js
+++ b/railway-deploy.js
@@ -2,7 +2,11 @@
 const { execSync } = require('child_process');
 const path = require('path');
 
-const token = process.env.RAILWAY_TOKEN || '2dc2f4ae-4e33-4ec4-a715-474a16792c00';
+const token = process.env.RAILWAY_TOKEN;
+if (!token) {
+  console.error('RAILWAY_TOKEN environment variable is required');
+  process.exit(1);
+}
 const railwayPath = path.join(__dirname, 'railway-cli-bin', 'bin', 'railway.js');
 
 try {


### PR DESCRIPTION
## What
- `deploy.js` + `railway-deploy.js`: read `RAILWAY_TOKEN` from env, fail fast if unset. Removes the hardcoded fallback.
- `.gitignore`: stop tracking `shared-memory/{logs,locks,results,reports}/` and `.worktrees/` — runtime artifacts the pipeline regenerates every run.

## Why
Code review flagged this as 3 critical security findings. Token was present verbatim on `develop`.

## ⚠️ Token rotation still required
This PR removes the token from HEAD. It does **not** remove it from git history — anyone who cloned before the merge (or who pulls old commits) still has it. **Rotate the Railway token in the dashboard** as soon as this merges; the old token should be revoked before this change is considered complete.

Generated manually (not via pipeline implement, because the affected files are outside the bot allowlist).