### PR TITLE
deps: add sqlalchemy 2.0 (step 0 of services→database migration)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ flask = "^3.0"
 pymysql = "^1.1"
 python-dotenv = "^1.0"
 gunicorn = "^21.0"
+sqlalchemy = "^2.0"
+psycopg2-binary = "^2.9"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pylint>=3.0"]


### PR DESCRIPTION
## Why
First of ~15 PRs migrating the services layer off in-memory dict mocks onto a real SQL backend per `sql/001_schema.sql` (51 tables).

This PR **only** adds the dep — it does not introduce any imports of sqlalchemy. Follow-up PRs do that.

## Roadmap
- [x] **0** — add sqlalchemy dep (this PR)
- [ ] 1 — `src/internal/db/engine.py` + `Base` + `SessionLocal`
- [ ] 2–5 — ORM models in 4 batches (10 tables each)
- [ ] 6 — `src/internal/repository/base.py` generic CRUD
- [ ] 7–20 — per-service rewire (CustomerService, TicketService, …)

## Why not aiosqlite / psycopg2-binary here
Tests use the stdlib `sqlite3` driver (ships with Python). Prod driver choice (mysql vs postgres) is deferred to when infra lands. Add it then.

## Manual PR
Bot allowlist is `src/` + `tests/` only — `pyproject.toml` edits need human authorship. Once this merges, the remaining 14 PRs can go through the autonomous pipeline.