### PR TITLE
deps: add alembic 1.13 (Task 12 prep — ORM-driven migrations)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python-dotenv = "^1.0"
 gunicorn = "^21.0"
 sqlalchemy = "^2.0"
 psycopg2-binary = "^2.9"
+alembic = "^1.13"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pylint>=3.0"]


### PR DESCRIPTION
## Why
Alembic will replace the MySQL-flavoured `sql/001_schema.sql` with autogenerated, Postgres-correct migrations once the ORM batches (Tasks 06–08 in the db-migration roadmap) land. SQLAlchemy emits dialect-correct DDL; alembic gives us migration history.

## What
+1 line in `pyproject.toml`. No code touches alembic in this PR — unblocks Task 12.

## Plan after merge
- Tasks 06–08 (ORM models, all batches) land via the autonomous pipeline
- Task 12 (manually queued in the roadmap): `alembic init src/internal/db/migrations`, autogenerate revision from `Base.metadata`, apply to Supabase
- Task 13: archive (or delete) `sql/001_schema.sql`

## Manual PR
Bot allowlist is `src/` + `tests/` only — `pyproject.toml` edits need human authorship. Same pattern as PR #8.