### PR TITLE
develop → master

### DIFF
--- a/.github/workflows/implement-ready-issues.yml
+++ b/.github/workflows/implement-ready-issues.yml
@@ -25,7 +25,7 @@ jobs:
   implement:
     name: Implement next ready issue
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: write
       issues: write
@@ -121,6 +121,10 @@ jobs:
           PLAN_PATH: ${{ steps.plan.outputs.plan_path }}
           DATABASE_URL: postgresql+asyncpg://test_user:test_pass@localhost:5432/test_db
           PYTHONPATH: src
+          # 60 min cap. Leaves ~30 min of the 90-min job budget for Stage 1
+          # (~2 min), docker + deps setup (~10 min), Stage 3 self-review,
+          # and the commit/PR step.
+          CLAUDE_TIMEOUT_SECONDS: '3600'
         run: python3 scripts/ci/execute_implementation.py
 
       - name: Stage 3 — self-review & fix

--- a/scripts/ci/execute_implementation.py
+++ b/scripts/ci/execute_implementation.py
@@ -150,7 +150,14 @@ def main() -> int:
         "claude", "-p",
         "--model", model,
         "--max-turns", max_turns,
-        "--output-format", "json",
+        # stream-json emits one JSON event per turn (tool call / tool result /
+        # assistant message) instead of buffering a single blob until the end.
+        # Combined with stream_claude()'s line-by-line forwarding, this gives
+        # live progress in the workflow log — essential for diagnosing where a
+        # long run got stuck before CLAUDE_TIMEOUT_SECONDS fires. `--verbose`
+        # is required by the CLI when streaming -p output.
+        "--output-format", "stream-json",
+        "--verbose",
         # Headless `-p` mode defaults to interactive permission prompts on
         # Write/Edit/Bash — but there's no interactive terminal in CI, so
         # every tool call gets silently denied. The previous 8-minute run


### PR DESCRIPTION
Auto-created by CI from branch `develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended job execution timeout window from 60 to 90 minutes for longer-running operations
  * Improved real-time progress visibility during workflow execution through enhanced logging

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yihua-zhuo/agent-job/pull/325)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->