### PR TITLE
Auto: implement issue #502

### DIFF
--- a/.plans/issue-502.md
+++ b/.plans/issue-502.md
@@ -1,0 +1,37 @@
+Now I have enough context. Here is the plan.
+
+# Implementation Plan — Issue #502
+
+## Goal
+Create `src/websocket/manager.py` with a `ConnectionManager` class that manages WebSocket connections in named rooms using an in-memory dict mapping room identifiers to sets of WebSocket clients. The class provides `join`, `leave`, `broadcast`, and channel subscribe/unsubscribe methods. All methods are `async`, return nothing, and raise no errors. A corresponding unit test suite in `tests/unit/test_websocket_manager.py` covers the five required behavioral cases.
+
+## Affected Files
+- `src/websocket/manager.py` — **new** — `ConnectionManager` class implementing in-memory room → set[WebSocket] mapping
+- `tests/unit/test_websocket_manager.py` — **new** — unit tests for all `ConnectionManager` methods
+
+## Implementation Steps
+1. Create the `src/websocket/` directory (it does not exist yet; `src/` has no `websocket` subdirectory).
+2. Write `src/websocket/manager.py` with:
+   - `class ConnectionManager` stored in `src.websocket.manager`.
+   - Internal state: `self._rooms: dict[str, set[Any]]` — a `dict` mapping room name strings to a `set` of WebSocket objects. Use `Any` or a minimal `Protocol` for the WebSocket type to avoid a hard FastAPI/Starlette import dependency in the class itself.
+   - `async def join(self, room: str, websocket: Any) -> None` — adds the websocket to `self._rooms.setdefault(room, set())`. Silently succeeds if already present. Returns `None`.
+   - `async def leave(self, room: str, websocket: Any) -> None` — removes the websocket from the room's set. Silently succeeds if not present or room doesn't exist. Returns `None`.
+   - `async def broadcast(self, room: str, message: str) -> None` — iterates over the room's set, calls `await ws.send_text(message)` for each. Silently skips if room is empty or doesn't exist. Raises nothing.
+   - `async def subscribe(self, channel: str, websocket: Any) -> None` and `async def unsubscribe(self, channel: str, websocket: Any) -> None` — identical logic to join/leave but keyed on channel name (can reuse the same `_rooms` dict; "room" and "channel" are the same mechanism with different naming).
+3. Use an `asyncio.Lock` (e.g., `self._lock = asyncio.Lock()`) to protect `_rooms` mutations and prevent concurrent modification during iteration in `broadcast`. Initialize it in `__init__`.
+
+## Test Plan
+- Unit tests in `tests/unit/test_websocket_manager.py`:
+  - `test_join_adds_connection` — call `manager.join("room1", ws)` twice, verify the set has 1 entry (deduplication).
+  - `test_leave_removes_connection` — join then leave, verify the set is empty.
+  - `test_broadcast_sends_to_all_in_room` — join 3 websockets to "room1", broadcast, assert `send_text` was called exactly once on each.
+  - `test_broadcast_to_empty_room_is_noop` — call `manager.broadcast("nonexistent", "msg")`, assert no `send_text` was called on any mock.
+  - `test_client_in_room_a_does_not_receive_broadcast_to_room_b` — join ws1 to "roomA" and ws2 to "roomB", broadcast to "roomA", assert ws2's `send_text` was never called.
+  - Tests use `unittest.mock.MagicMock()` as WebSocket stand-ins with `send_text = AsyncMock()` injected. No database, no `pytest-asyncio` DB fixtures needed. Use `pytest.mark.asyncio` for all test methods. Import `ConnectionManager` from `src.websocket.manager` after ensuring `src/` is on `sys.path` (already handled by the existing conftest.py `sys.path` setup).
+
+## Acceptance Criteria
+- `manager.join("room", ws)` followed by `manager.leave("room", ws)` results in an empty room — no errors raised.
+- `manager.broadcast("room", "msg")` calls `send_text` on every WebSocket that has previously called `join` for that room and has not called `leave`.
+- Calling `broadcast` on a room with zero connections completes silently with no errors.
+- After `ws_a.join("room1")` and `ws_b.join("room2")`, a `broadcast("room1", "msg")` does not call `ws_b.send_text`.
+- All five test cases pass with `pytest tests/unit/test_websocket_manager.py -v`.

--- a/.plans/issue-502.md
+++ b/.plans/issue-502.md
@@ -27,7 +27,7 @@ Create `src/websocket/manager.py` with a `ConnectionManager` class that manages 
   - `test_broadcast_sends_to_all_in_room` — join 3 websockets to "room1", broadcast, assert `send_text` was called exactly once on each.
   - `test_broadcast_to_empty_room_is_noop` — call `manager.broadcast("nonexistent", "msg")`, assert no `send_text` was called on any mock.
   - `test_client_in_room_a_does_not_receive_broadcast_to_room_b` — join ws1 to "roomA" and ws2 to "roomB", broadcast to "roomA", assert ws2's `send_text` was never called.
-  - Tests use `unittest.mock.MagicMock()` as WebSocket stand-ins with `send_text = AsyncMock()` injected. No database, no `pytest-asyncio` DB fixtures needed. Use `pytest.mark.asyncio` for all test methods. Import `ConnectionManager` from `src.websocket.manager` after ensuring `src/` is on `sys.path` (already handled by the existing conftest.py `sys.path` setup).
+  - Tests use `unittest.mock.MagicMock()` as WebSocket stand-ins with `send_text = AsyncMock()` injected. No database, no explicit `pytest.mark.asyncio` markers needed — pytest-asyncio's auto mode detects and runs the `async def` test methods automatically. Import `ConnectionManager` from `src.websocket.manager` after ensuring `src/` is on `sys.path` (already handled by the existing conftest.py `sys.path` setup).
 
 ## Acceptance Criteria
 - `manager.join("room", ws)` followed by `manager.leave("room", ws)` results in an empty room — no errors raised.

--- a/.plans/issue-502.md
+++ b/.plans/issue-502.md
@@ -27,7 +27,11 @@ Create `src/websocket/manager.py` with a `ConnectionManager` class that manages 
   - `test_broadcast_sends_to_all_in_room` — join 3 websockets to "room1", broadcast, assert `send_text` was called exactly once on each.
   - `test_broadcast_to_empty_room_is_noop` — call `manager.broadcast("nonexistent", "msg")`, assert no `send_text` was called on any mock.
   - `test_client_in_room_a_does_not_receive_broadcast_to_room_b` — join ws1 to "roomA" and ws2 to "roomB", broadcast to "roomA", assert ws2's `send_text` was never called.
-  - Tests use `unittest.mock.MagicMock()` as WebSocket stand-ins with `send_text = AsyncMock()` injected. No database, no explicit `pytest.mark.asyncio` markers needed — pytest-asyncio's auto mode detects and runs the `async def` test methods automatically. Import `ConnectionManager` from `src.websocket.manager` after ensuring `src/` is on `sys.path` (already handled by the existing conftest.py `sys.path` setup).
+  - `test_subscribe_adds_connection` — subscribe then verify the channel entry exists with the websocket.
+  - `test_unsubscribe_removes_connection` — subscribe then unsubscribe, verify the websocket is removed.
+  - Tests use `unittest.mock.MagicMock()` as WebSocket stand-ins with `send_text = AsyncMock()` injected. No database. Requires pytest-asyncio in auto mode (``asyncio_mode = auto`` in ``pytest.ini`` or ``pytestmark = pytest.mark.asyncio`` on the module) so that explicit ``pytest.mark.asyncio`` markers on each ``async def`` test are unnecessary. Import ``ConnectionManager`` from ``src.websocket.manager`` after ensuring ``src/`` is on ``sys.path`` (already handled by the existing conftest.py ``sys.path`` setup).
+
+> **Note:** Rooms and channels share the same internal namespace (``self._rooms``). If a client joins room ``"foo"`` and subscribes to channel ``"foo"``, both entries merge into the same set. This is by design — callers must use distinct names for rooms and channels to avoid collisions.
 
 ## Acceptance Criteria
 - `manager.join("room", ws)` followed by `manager.leave("room", ws)` results in an empty room — no errors raised.

--- a/src/websocket/manager.py
+++ b/src/websocket/manager.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self._rooms: dict[str, set[Any]] = {}
+        self._lock = asyncio.Lock()
+
+    async def join(self, room: str, websocket: Any) -> None:
+        async with self._lock:
+            self._rooms.setdefault(room, set()).add(websocket)
+
+    async def leave(self, room: str, websocket: Any) -> None:
+        async with self._lock:
+            if room in self._rooms:
+                self._rooms[room].discard(websocket)
+                if not self._rooms[room]:
+                    del self._rooms[room]
+
+    async def broadcast(self, room: str, message: str) -> None:
+        async with self._lock:
+            websockets = list(self._rooms.get(room, []))
+
+        for ws in websockets:
+            await ws.send_text(message)
+
+    async def subscribe(self, channel: str, websocket: Any) -> None:
+        async with self._lock:
+            self._rooms.setdefault(channel, set()).add(websocket)
+
+    async def unsubscribe(self, channel: str, websocket: Any) -> None:
+        async with self._lock:
+            if channel in self._rooms:
+                self._rooms[channel].discard(websocket)
+                if not self._rooms[channel]:
+                    del self._rooms[channel]

--- a/src/websocket/manager.py
+++ b/src/websocket/manager.py
@@ -8,16 +8,26 @@ _logger = logging.getLogger(__name__)
 
 
 class ConnectionManager:
+    """Manages WebSocket connections grouped by room or channel.
+
+    Rooms and channels share the same underlying namespace
+    (``self._rooms``); callers must use distinct names to avoid
+    collisions (e.g. a client joining room ``"foo"`` and subscribing to
+    channel ``"foo"`` will occupy the same entry).
+    """
+
     def __init__(self) -> None:
         self._rooms: dict[str, set[Any]] = {}
         self._lock = asyncio.Lock()
 
     async def join(self, room: str, websocket: Any) -> None:
+        """Add ``websocket`` to ``room``. Silently succeeds if already present."""
         async with self._lock:
             self._rooms.setdefault(room, set()).add(websocket)
         _logger.debug("WebSocket joined room %s", room)
 
     async def leave(self, room: str, websocket: Any) -> None:
+        """Remove ``websocket`` from ``room``. Silently succeeds if absent."""
         async with self._lock:
             if room in self._rooms:
                 self._rooms[room].discard(websocket)
@@ -26,32 +36,29 @@ class ConnectionManager:
         _logger.debug("WebSocket left room %s", room)
 
     async def broadcast(self, room: str, message: str) -> None:
+        """Send ``message`` to every WebSocket in ``room``. Silently skips if room is empty or absent."""
         async with self._lock:
             websockets = list(self._rooms.get(room, []))
-            await asyncio.sleep(0)
-
-        delivered = 0
-        for ws in websockets:
-            try:
-                await ws.send_text(message)
-                delivered += 1
-            except Exception as e:
-                if isinstance(e, asyncio.CancelledError):
-                    raise
-                _logger.warning("Failed to send to WebSocket in room %s, removing", room)
-                async with self._lock:
-                    if room in self._rooms:
-                        self._rooms[room].discard(ws)
-                        if not self._rooms[room]:
-                            del self._rooms[room]
-                continue
-        _logger.debug("Broadcast to room %s delivered to %d clients", room, delivered)
+            # Re-acquire the lock to protect send-and-remove from concurrent join/leave.
+            for ws in websockets:
+                try:
+                    await ws.send_text(message)
+                except Exception as e:
+                    if isinstance(e, asyncio.CancelledError):
+                        raise
+                    _logger.warning("Failed to send to WebSocket in room %s, removing", room)
+                    self._rooms[room].discard(ws)
+                    if not self._rooms[room]:
+                        del self._rooms[room]
+        _logger.debug("Broadcast to room %s completed", room)
 
     async def subscribe(self, channel: str, websocket: Any) -> None:
+        """Add ``websocket`` to ``channel`` (alias for :meth:`join` with a different namespace)."""
         async with self._lock:
             self._rooms.setdefault(channel, set()).add(websocket)
 
     async def unsubscribe(self, channel: str, websocket: Any) -> None:
+        """Remove ``websocket`` from ``channel`` (alias for :meth:`leave` with a different namespace)."""
         async with self._lock:
             if channel in self._rooms:
                 self._rooms[channel].discard(websocket)

--- a/src/websocket/manager.py
+++ b/src/websocket/manager.py
@@ -28,23 +28,24 @@ class ConnectionManager:
     async def broadcast(self, room: str, message: str) -> None:
         async with self._lock:
             websockets = list(self._rooms.get(room, []))
+            await asyncio.sleep(0)
 
-        if not websockets:
-            _logger.debug("Broadcast to room %s: no clients connected", room)
-            return
-
-        await asyncio.sleep(0)
-
+        delivered = 0
         for ws in websockets:
             try:
                 await ws.send_text(message)
-            except Exception:
+                delivered += 1
+            except Exception as e:
+                if isinstance(e, asyncio.CancelledError):
+                    raise
                 _logger.warning("Failed to send to WebSocket in room %s, removing", room)
                 async with self._lock:
                     if room in self._rooms:
                         self._rooms[room].discard(ws)
+                        if not self._rooms[room]:
+                            del self._rooms[room]
                 continue
-        _logger.debug("Broadcast to room %s delivered to %d clients", room, len(websockets))
+        _logger.debug("Broadcast to room %s delivered to %d clients", room, delivered)
 
     async def subscribe(self, channel: str, websocket: Any) -> None:
         async with self._lock:

--- a/src/websocket/manager.py
+++ b/src/websocket/manager.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
+
+_logger = logging.getLogger(__name__)
 
 
 class ConnectionManager:
@@ -12,6 +15,7 @@ class ConnectionManager:
     async def join(self, room: str, websocket: Any) -> None:
         async with self._lock:
             self._rooms.setdefault(room, set()).add(websocket)
+        _logger.debug("WebSocket joined room %s", room)
 
     async def leave(self, room: str, websocket: Any) -> None:
         async with self._lock:
@@ -19,13 +23,28 @@ class ConnectionManager:
                 self._rooms[room].discard(websocket)
                 if not self._rooms[room]:
                     del self._rooms[room]
+        _logger.debug("WebSocket left room %s", room)
 
     async def broadcast(self, room: str, message: str) -> None:
         async with self._lock:
             websockets = list(self._rooms.get(room, []))
 
+        if not websockets:
+            _logger.debug("Broadcast to room %s: no clients connected", room)
+            return
+
+        await asyncio.sleep(0)
+
         for ws in websockets:
-            await ws.send_text(message)
+            try:
+                await ws.send_text(message)
+            except Exception:
+                _logger.warning("Failed to send to WebSocket in room %s, removing", room)
+                async with self._lock:
+                    if room in self._rooms:
+                        self._rooms[room].discard(ws)
+                continue
+        _logger.debug("Broadcast to room %s delivered to %d clients", room, len(websockets))
 
     async def subscribe(self, channel: str, websocket: Any) -> None:
         async with self._lock:

--- a/tests/unit/test_websocket_manager.py
+++ b/tests/unit/test_websocket_manager.py
@@ -36,8 +36,13 @@ def ws_c():
 class TestJoin:
     async def test_join_adds_connection(self, manager, ws_a, ws_b):
         await manager.join("room1", ws_a)
+        assert len(manager._rooms["room1"]) == 1
+
+    async def test_join_deduplicates(self, manager, ws_a, ws_b):
+        await manager.join("room1", ws_a)
         await manager.join("room1", ws_a)
         await manager.join("room1", ws_b)
+        assert len(manager._rooms["room1"]) == 2
         await manager.broadcast("room1", "hello")
         ws_a.send_text.assert_called_once_with("hello")
         ws_b.send_text.assert_called_once_with("hello")
@@ -67,6 +72,32 @@ class TestBroadcast:
         await manager.broadcast("nonexistent", "msg")
         ws_a.send_text.assert_not_called()
         ws_b.send_text.assert_not_called()
+
+
+class TestSubscribe:
+    async def test_subscribe_adds_connection(self, manager, ws_a):
+        await manager.subscribe("channel1", ws_a)
+        assert "channel1" in manager._rooms
+        assert len(manager._rooms["channel1"]) == 1
+
+    async def test_subscribe_deduplicates(self, manager, ws_a, ws_b):
+        await manager.subscribe("channel1", ws_a)
+        await manager.subscribe("channel1", ws_a)
+        await manager.subscribe("channel1", ws_b)
+        assert len(manager._rooms["channel1"]) == 2
+
+
+class TestUnsubscribe:
+    async def test_unsubscribe_removes_connection(self, manager, ws_a, ws_b):
+        await manager.subscribe("channel1", ws_a)
+        await manager.subscribe("channel1", ws_b)
+        await manager.unsubscribe("channel1", ws_a)
+        assert len(manager._rooms["channel1"]) == 1
+        assert ws_a not in manager._rooms["channel1"]
+        assert ws_b in manager._rooms["channel1"]
+
+    async def test_unsubscribe_nonexistent_is_noop(self, manager, ws_a):
+        await manager.unsubscribe("nonexistent", ws_a)
 
     async def test_client_in_room_a_does_not_receive_broadcast_to_room_b(
         self, manager, ws_a, ws_b

--- a/tests/unit/test_websocket_manager.py
+++ b/tests/unit/test_websocket_manager.py
@@ -86,6 +86,16 @@ class TestSubscribe:
         await manager.subscribe("channel1", ws_b)
         assert len(manager._rooms["channel1"]) == 2
 
+    async def test_subscribe_channel_sends_to_all(self, manager, ws_a, ws_b, ws_c):
+        """Subscribe mirrors join/leave pattern — verify broadcast reaches all subscribers."""
+        await manager.subscribe("channel1", ws_a)
+        await manager.subscribe("channel1", ws_b)
+        await manager.subscribe("channel1", ws_c)
+        await manager.broadcast("channel1", "hello")
+        ws_a.send_text.assert_called_once_with("hello")
+        ws_b.send_text.assert_called_once_with("hello")
+        ws_c.send_text.assert_called_once_with("hello")
+
 
 class TestUnsubscribe:
     async def test_unsubscribe_removes_connection(self, manager, ws_a, ws_b):
@@ -99,9 +109,26 @@ class TestUnsubscribe:
     async def test_unsubscribe_nonexistent_is_noop(self, manager, ws_a):
         await manager.unsubscribe("nonexistent", ws_a)
 
+    async def test_unsubscribe_prevents_future_broadcast(self, manager, ws_a, ws_b):
+        """Unsubscribe mirrors leave — unsubscribed client must not receive future broadcasts."""
+        await manager.subscribe("channel1", ws_a)
+        await manager.subscribe("channel1", ws_b)
+        await manager.unsubscribe("channel1", ws_a)
+        await manager.broadcast("channel1", "hello")
+        ws_a.send_text.assert_not_called()
+        ws_b.send_text.assert_called_once_with("hello")
+
     async def test_client_in_room_a_does_not_receive_broadcast_to_room_b(
         self, manager, ws_a, ws_b
     ):
+        """Deduplication: clients in the same room must not receive duplicate messages."""
+        await manager.join("roomA", ws_a)
+        await manager.join("roomA", ws_a)  # join twice — set deduplication
+        await manager.broadcast("roomA", "hello")
+        ws_a.send_text.assert_called_once_with("hello")
+
+    async def test_ws_in_room_b_isolation(self, manager, ws_a, ws_b):
+        """Cross-room isolation: ws_b in roomB must never be called when broadcasting to roomA."""
         await manager.join("roomA", ws_a)
         await manager.join("roomB", ws_b)
         await manager.broadcast("roomA", "hello")

--- a/tests/unit/test_websocket_manager.py
+++ b/tests/unit/test_websocket_manager.py
@@ -34,20 +34,23 @@ def ws_c():
 
 
 class TestJoin:
-    async def test_join_adds_connection(self, manager, ws_a):
+    async def test_join_adds_connection(self, manager, ws_a, ws_b):
         await manager.join("room1", ws_a)
         await manager.join("room1", ws_a)
-        async with manager._lock:
-            assert manager._rooms == {"room1": {ws_a}}
-        assert len(manager._rooms["room1"]) == 1
+        await manager.join("room1", ws_b)
+        await manager.broadcast("room1", "hello")
+        ws_a.send_text.assert_called_once_with("hello")
+        ws_b.send_text.assert_called_once_with("hello")
 
 
 class TestLeave:
-    async def test_leave_removes_connection(self, manager, ws_a):
+    async def test_leave_removes_connection(self, manager, ws_a, ws_b):
         await manager.join("room1", ws_a)
+        await manager.join("room1", ws_b)
         await manager.leave("room1", ws_a)
-        async with manager._lock:
-            assert manager._rooms == {}
+        await manager.broadcast("room1", "hello")
+        ws_a.send_text.assert_not_called()
+        ws_b.send_text.assert_called_once_with("hello")
 
 
 class TestBroadcast:

--- a/tests/unit/test_websocket_manager.py
+++ b/tests/unit/test_websocket_manager.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.websocket.manager import ConnectionManager
+
+
+@pytest.fixture
+def manager():
+    return ConnectionManager()
+
+
+@pytest.fixture
+def ws_a():
+    ws = MagicMock()
+    ws.send_text = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def ws_b():
+    ws = MagicMock()
+    ws.send_text = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def ws_c():
+    ws = MagicMock()
+    ws.send_text = AsyncMock()
+    return ws
+
+
+class TestJoin:
+    async def test_join_adds_connection(self, manager, ws_a):
+        await manager.join("room1", ws_a)
+        await manager.join("room1", ws_a)
+        async with manager._lock:
+            assert manager._rooms == {"room1": {ws_a}}
+        assert len(manager._rooms["room1"]) == 1
+
+
+class TestLeave:
+    async def test_leave_removes_connection(self, manager, ws_a):
+        await manager.join("room1", ws_a)
+        await manager.leave("room1", ws_a)
+        async with manager._lock:
+            assert manager._rooms == {}
+
+
+class TestBroadcast:
+    async def test_broadcast_sends_to_all_in_room(self, manager, ws_a, ws_b, ws_c):
+        await manager.join("room1", ws_a)
+        await manager.join("room1", ws_b)
+        await manager.join("room1", ws_c)
+        await manager.broadcast("room1", "hello")
+        ws_a.send_text.assert_called_once_with("hello")
+        ws_b.send_text.assert_called_once_with("hello")
+        ws_c.send_text.assert_called_once_with("hello")
+
+    async def test_broadcast_to_empty_room_is_noop(self, manager, ws_a, ws_b):
+        await manager.broadcast("nonexistent", "msg")
+        ws_a.send_text.assert_not_called()
+        ws_b.send_text.assert_not_called()
+
+    async def test_client_in_room_a_does_not_receive_broadcast_to_room_b(
+        self, manager, ws_a, ws_b
+    ):
+        await manager.join("roomA", ws_a)
+        await manager.join("roomB", ws_b)
+        await manager.broadcast("roomA", "hello")
+        ws_a.send_text.assert_called_once_with("hello")
+        ws_b.send_text.assert_not_called()


### PR DESCRIPTION
Closes #502

Plan: `.plans/issue-502.md`

This PR was auto-implemented by Claude Code in three stages:

1. **Plan** — Claude wrote a detailed implementation plan to `.plans/issue-502.md`.
2. **Implement** — Claude executed the plan, ran `ruff check src/` + the unit and integration test suites, and iterated until all three were green.
3. **Self-review** — Claude reviewed its own diff against `codereview.md` (the project review checklist) and fixed any rule violations found, re-running the test suite if any changes were made.

PR-time CI (`Dev Agent CI`) re-verifies independently before this PR is mergeable.

Please review before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WebSocket connection manager for room/channel grouping, concurrency-safe join/leave/subscribe/unsubscribe, reliable broadcast delivery, automatic cleanup of disconnected clients, and no-duplicate deliveries.

* **Tests**
  * Added unit tests covering join, leave, broadcast behavior, empty-room no-ops, and isolation between rooms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yihua-zhuo/agent-job/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->