### PR TITLE
Auto: implement issue #511

### DIFF
--- a/.plans/issue-511.md
+++ b/.plans/issue-511.md
@@ -1,0 +1,52 @@
+Now I have enough context to write the plan.
+
+---
+
+# Implementation Plan — Issue #511
+
+## Goal
+Build `EnrichmentService` in `src/services/enrichment_service.py` as the first provider-backed service in the enrichment subsystem, with `POST /api/v1/enrichment/lookup` in `src/api/routers/enrichment.py` as the sole public endpoint. The endpoint accepts a company domain or name, calls the Clearbit Company API (key driven by a config setting), normalizes the response into a company data dict, persists the raw payload to the `customer_enrichments` table already provisioned by issue #510, and returns the enriched fields.
+
+## Source Contract
+GitHub issue #511 body and repository files inspected during planning:
+- `src/configs/settings.py` — config pattern (pydantic-settings `Field`, settings singleton)
+- `src/services/ai_service.py` — service pattern (`AsyncSession` constructor arg, no default, raises `AppException`)
+- `src/api/routers/ai.py` — router pattern (`_success()` wrapper, `Depends(get_db)`, `require_auth`)
+- `src/db/models/customer_enrichment.py` — ORM model already created by issue #510 (FK to `customers.id`, `raw_data_json`, `provider`)
+- `tests/unit/test_ai_service.py` — unit test style (mock `session.execute`, mock gateway, `MagicMock`/`AsyncMock`)
+- `tests/unit/test_ai_router.py` — router test style (`FastAPI.TestClient`, monkeypatched `require_auth`/`get_db`)
+- `src/db/connection.py` — `get_db` dependency## Affected Files
+- `src/configs/settings.py` — Add `clearbit_api_key: str | None` field- `src/services/enrichment_service.py` — New file: `EnrichmentService` class with `lookup(domain, provider) -> dict`
+- `src/api/routers/enrichment.py` — New file: `POST /api/v1/enrichment/lookup` endpoint
+- `tests/unit/test_enrichment_service.py` — New file: unit tests for the service
+- `tests/unit/test_enrichment_router.py` — New file: unit tests for the router endpoint
+
+## Implementation Steps
+1. **Add `clearbit_api_key` to settings**: In `src/configs/settings.py`, add `clearbit_api_key: str | None = Field(default=None)` alongside the other auth/API fields. No validation gate is needed (enrichment is optional functionality).
+2. **Create `src/services/enrichment_service.py`**: Define `EnrichmentService(session: AsyncSession)` (no gateway/default). Implement `async def lookup(self, domain: str | None, company_name: str | None) -> dict` that:
+   - Requires exactly one of `domain`/`company_name` (raise `ValidationException` if both or neither given).
+   - Dispatches to `_lookup_clearbit()` for `provider="clearbit"`.
+   - Uses `httpx.AsyncClient` to `GET https://company.clearbit.com/v2/companies/find?name=<company_name>` or `?domain=<domain>` with `Authorization: Bearer <clearbit_api_key>` header.
+   - On non-2xx HTTP response (including 404 "company not found") raise `ValidationException("Clearbit API error")`.
+   - Normalize the Clearbit JSON into a flat `dict` with keys such as `name`, `domain`, `legal_name`, `category`, `geo`, `metrics`, `linkedin`, `logo` (include only present keys).
+   - Insert a `CustomerEnrichmentModel` row with `customer_id=None` (null for now; future flow will pass `customer_id`), `provider="clearbit"`, `raw_data_json=clearbit_response`, `enriched_at=now`.
+   - Return the normalized dict.
+   - Raise `ValidationException` for unknown `provider`.
+3. **Create `src/api/routers/enrichment.py`**: Define an `enrichment_router = APIRouter(prefix="/api/v1/enrichment", tags=["enrichment"])`. Add `POST /lookup` with body `EnrichmentLookupRequest(domain: str | None = None, company_name: str | None = None)` (Pydantic model in `models/enrichment.py`). The endpoint calls `EnrichmentService(session).lookup(...)`, wraps in `_success()`, and returns the envelope dict.
+4. **Validate dependency order**: The service inserts a `CustomerEnrichmentModel` row — verify `CustomerEnrichmentModel` is importable and its table has been migrated via the existing issue #510 migration (`create_customer_enrichments`). No new migration required.
+
+## Test Plan
+- Unit tests in `tests/unit/`: `test_enrichment_service.py` — mock `httpx.AsyncClient` via `AsyncMock`/`MagicMock` patched at the `httpx.AsyncClient` class level; test `lookup` with domain, with company_name, with neither (raises `ValidationException`), with both (raises `ValidationException`), HTTP 404 (raises `ValidationException`), HTTP 500 (raises `ValidationException`), provider=clearbit success (returns normalized dict). Also test that `CustomerEnrichmentModel` is added to the session.
+- Unit tests in `tests/unit/`: `test_enrichment_router.py` — create a `TestClient` via `FastAPI.TestClient`, monkeypatch `require_auth` (returns `AuthContext`) and `get_db` (returns `MagicMock`); mock `EnrichmentService.lookup` with `AsyncMock`; assert correct envelope shape and HTTP200 on success and HTTP 422 on validation failure.
+- Dev-plan verification: Run `pytest tests/unit/test_enrichment_service.py tests/unit/test_enrichment_router.py -v` and `ruff check src/services/enrichment_service.py src/api/routers/enrichment.py`.
+
+## Acceptance Criteria
+- `src/services/enrichment_service.py` passes `ruff check` and `mypy` without errors.
+- `src/api/routers/enrichment.py` registers at `/api/v1/enrichment/lookup` in the FastAPI app.
+- `EnrichmentService.lookup(domain="stripe.com", provider="clearbit")` returns a `dict` with at least `name` and `domain` when Clearbit responds 200.
+- `EnrichmentService.lookup(domain=None, company_name=None)` raises `ValidationException`.
+- `EnrichmentService.lookup(domain=None, company_name=None)` when both are provided raises `ValidationException`.
+- HTTP404 from Clearbit raises `ValidationException("Clearbit API error")`.
+- `CustomerEnrichmentModel` is inserted into the session on every successful lookup.
+- `pytest tests/unit/test_enrichment_service.py tests/unit/test_enrichment_router.py -v` passes with zero test errors.
+- No Apollo, ZoomInfo, or other provider code is present in the implementation.

--- a/.plans/issue-511.md
+++ b/.plans/issue-511.md
@@ -23,13 +23,15 @@ GitHub issue #511 body and repository files inspected during planning:
 
 ## Implementation Steps
 1. **Add `clearbit_api_key` to settings**: In `src/configs/settings.py`, add `clearbit_api_key: str | None = Field(default=None)` alongside the other auth/API fields. No validation gate is needed (enrichment is optional functionality).
-2. **Create `src/services/enrichment_service.py`**: Define `EnrichmentService(session: AsyncSession)` (no gateway/default). Implement `async def lookup(self, domain: str | None, company_name: str | None) -> dict` that:
+2. **Create `src/services/enrichment_service.py`**: Define `EnrichmentService(session: AsyncSession)` (no gateway/default). Implement `async def lookup(self, domain: str | None, company_name: str | None, *, tenant_id: int | None = None, customer_id: int | None = None) -> dict` that:
+   - Normalises `domain` and `company_name` by stripping whitespace and treating blank strings as absent.
    - Requires exactly one of `domain`/`company_name` (raise `ValidationException` if both or neither given).
+   - When `tenant_id` is provided, looks up the customer and raises `NotFoundException` if the `customer_id` does not belong to that tenant.
    - Dispatches to `_lookup_clearbit()` for `provider="clearbit"`.
    - Uses `httpx.AsyncClient` to `GET https://company.clearbit.com/v2/companies/find?name=<company_name>` or `?domain=<domain>` with `Authorization: Bearer <clearbit_api_key>` header.
-   - On non-2xx HTTP response (including 404 "company not found") raise `ValidationException("Clearbit API error")`.
+   - On HTTP 404 raise `ValidationException("No company found for the given domain or name")`; on other non-2xx responses raise `ValidationException(f"Clearbit API error: {status_code}")`.
    - Normalize the Clearbit JSON into a flat `dict` with keys such as `name`, `domain`, `legal_name`, `category`, `geo`, `metrics`, `linkedin`, `logo` (include only present keys).
-   - Insert a `CustomerEnrichmentModel` row with `customer_id=None` (null for now; future flow will pass `customer_id`), `provider="clearbit"`, `raw_data_json=clearbit_response`, `enriched_at=now`.
+   - Insert a `CustomerEnrichmentModel` row with `customer_id`, `provider="clearbit"`, `raw_data_json=clearbit_response`, `enriched_at=now`.
    - Return the normalized dict.
    - Raise `ValidationException` for unknown `provider`.
 3. **Create `src/api/routers/enrichment.py`**: Define an `enrichment_router = APIRouter(prefix="/api/v1/enrichment", tags=["enrichment"])`. Add `POST /lookup` with body `EnrichmentLookupRequest(domain: str | None = None, company_name: str | None = None)` (Pydantic model in `models/enrichment.py`). The endpoint calls `EnrichmentService(session).lookup(...)`, wraps in `_success()`, and returns the envelope dict.
@@ -46,7 +48,7 @@ GitHub issue #511 body and repository files inspected during planning:
 - `EnrichmentService.lookup(domain="stripe.com", provider="clearbit")` returns a `dict` with at least `name` and `domain` when Clearbit responds 200.
 - `EnrichmentService.lookup(domain=None, company_name=None)` raises `ValidationException`.
 - `EnrichmentService.lookup(domain=None, company_name=None)` when both are provided raises `ValidationException`.
-- HTTP404 from Clearbit raises `ValidationException("Clearbit API error")`.
+- HTTP404 from Clearbit raises `ValidationException("No company found for the given domain or name")`; other non-2xx raises `ValidationException("Clearbit API error: {status_code}")`.
 - `CustomerEnrichmentModel` is inserted into the session on every successful lookup.
 - `pytest tests/unit/test_enrichment_service.py tests/unit/test_enrichment_router.py -v` passes with zero test errors.
 - No Apollo, ZoomInfo, or other provider code is present in the implementation.

--- a/src/api/routers/enrichment.py
+++ b/src/api/routers/enrichment.py
@@ -1,6 +1,6 @@
 """Enrichment API router — ``POST /api/v1/enrichment/lookup``."""
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.connection import get_db
@@ -20,7 +20,6 @@ async def lookup(
     request: EnrichmentLookupRequest,
     ctx: AuthContext = Depends(require_auth),
     session: AsyncSession = Depends(get_db),
-    customer_id: int | None = Query(default=None, description="ID of the customer to associate the enrichment with"),
 ) -> dict:
     """Look up company enrichment data by domain or company name.
 
@@ -32,6 +31,6 @@ async def lookup(
         domain=request.domain,
         company_name=request.company_name,
         tenant_id=ctx.tenant_id,
-        customer_id=customer_id,
+        customer_id=request.customer_id,
     )
     return _success(result)

--- a/src/api/routers/enrichment.py
+++ b/src/api/routers/enrichment.py
@@ -1,0 +1,31 @@
+"""Enrichment API router — ``POST /api/v1/enrichment/lookup``."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.connection import get_db
+from internal.middleware.fastapi_auth import AuthContext, require_auth
+from models.enrichment import EnrichmentLookupRequest
+from services.enrichment_service import EnrichmentService
+
+enrichment_router = APIRouter(prefix="/api/v1/enrichment", tags=["enrichment"])
+
+
+def _success(data: dict, message: str = "") -> dict:
+    return {"success": True, "data": data, "message": message}
+
+
+@enrichment_router.post("/lookup")
+async def lookup(
+    request: EnrichmentLookupRequest,
+    ctx: AuthContext = Depends(require_auth),
+    session: AsyncSession = Depends(get_db),
+) -> dict:
+    """Look up company enrichment data by domain or company name.
+
+    Calls the configured third-party provider (Clearbit) and persists
+    the raw response to ``customer_enrichments``.
+    """
+    svc = EnrichmentService(session)
+    result = await svc.lookup(domain=request.domain, company_name=request.company_name)
+    return _success(result)

--- a/src/api/routers/enrichment.py
+++ b/src/api/routers/enrichment.py
@@ -1,6 +1,6 @@
 """Enrichment API router — ``POST /api/v1/enrichment/lookup``."""
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.connection import get_db
@@ -20,6 +20,7 @@ async def lookup(
     request: EnrichmentLookupRequest,
     ctx: AuthContext = Depends(require_auth),
     session: AsyncSession = Depends(get_db),
+    customer_id: int = Query(..., description="ID of the customer to associate the enrichment with"),
 ) -> dict:
     """Look up company enrichment data by domain or company name.
 
@@ -27,5 +28,10 @@ async def lookup(
     the raw response to ``customer_enrichments``.
     """
     svc = EnrichmentService(session)
-    result = await svc.lookup(domain=request.domain, company_name=request.company_name)
+    result = await svc.lookup(
+        domain=request.domain,
+        company_name=request.company_name,
+        tenant_id=ctx.tenant_id,
+        customer_id=customer_id,
+    )
     return _success(result)

--- a/src/api/routers/enrichment.py
+++ b/src/api/routers/enrichment.py
@@ -20,7 +20,7 @@ async def lookup(
     request: EnrichmentLookupRequest,
     ctx: AuthContext = Depends(require_auth),
     session: AsyncSession = Depends(get_db),
-    customer_id: int = Query(..., description="ID of the customer to associate the enrichment with"),
+    customer_id: int | None = Query(default=None, description="ID of the customer to associate the enrichment with"),
 ) -> dict:
     """Look up company enrichment data by domain or company name.
 
@@ -31,6 +31,7 @@ async def lookup(
     result = await svc.lookup(
         domain=request.domain,
         company_name=request.company_name,
+        tenant_id=ctx.tenant_id,
         customer_id=customer_id,
     )
     return _success(result)

--- a/src/api/routers/enrichment.py
+++ b/src/api/routers/enrichment.py
@@ -31,7 +31,6 @@ async def lookup(
     result = await svc.lookup(
         domain=request.domain,
         company_name=request.company_name,
-        tenant_id=ctx.tenant_id,
         customer_id=customer_id,
     )
     return _success(result)

--- a/src/configs/settings.py
+++ b/src/configs/settings.py
@@ -33,6 +33,9 @@ class Settings(BaseSettings):
     # OpenAPI
     openapi_enabled: bool = Field(default=True)
 
+    # Third-party enrichment
+    clearbit_api_key: str | None = Field(default=None, description="Clearbit Company API key")
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/src/configs/settings.py
+++ b/src/configs/settings.py
@@ -35,6 +35,8 @@ class Settings(BaseSettings):
 
     # Third-party enrichment
     clearbit_api_key: str | None = Field(default=None, description="Clearbit Company API key")
+    clearbit_connect_timeout: float = Field(default=5.0, ge=0.1, description="Clearbit connect timeout in seconds")
+    clearbit_read_timeout: float = Field(default=10.0, ge=0.1, description="Clearbit read timeout in seconds")
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/src/db/models/customer_enrichment.py
+++ b/src/db/models/customer_enrichment.py
@@ -20,7 +20,12 @@ class CustomerEnrichmentModel(Base):
         Integer, ForeignKey("customers.id", ondelete="CASCADE"), nullable=False, index=True
     )
 
-    __table_args__ = (UniqueConstraint("tenant_id", "customer_id", name="uq_enrichment_tenant_customer"),)
+    __table_args__ = (
+        # One enrichment record per provider per customer. Refresh scenarios are
+        # handled by application logic (upsert / re-insert with new timestamps) rather
+        # than updating the existing row, so this constraint prevents accidental overwrites.
+        UniqueConstraint("tenant_id", "customer_id", name="uq_enrichment_tenant_customer"),
+    )
     provider: Mapped[str] = mapped_column(String(100), nullable=False)
     raw_data_json: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
     enriched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -35,6 +40,8 @@ class CustomerEnrichmentModel(Base):
     )
 
     def to_dict(self) -> dict:
+        # Note: raw_data_json is included verbatim. Ensure the Clearbit payload
+        # contains no credentials or sensitive data before serializing.
         return {
             "id": self.id,
             "tenant_id": self.tenant_id,

--- a/src/db/models/customer_enrichment.py
+++ b/src/db/models/customer_enrichment.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, func
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -15,9 +15,12 @@ class CustomerEnrichmentModel(Base):
     __tablename__ = "customer_enrichments"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    tenant_id: Mapped[int] = mapped_column(Integer, ForeignKey("tenants.id"), nullable=False, index=True)
     customer_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("customers.id", ondelete="CASCADE"), nullable=False, index=True
     )
+
+    __table_args__ = (UniqueConstraint("tenant_id", "customer_id", name="uq_enrichment_tenant_customer"),)
     provider: Mapped[str] = mapped_column(String(100), nullable=False)
     raw_data_json: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
     enriched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -34,6 +37,7 @@ class CustomerEnrichmentModel(Base):
     def to_dict(self) -> dict:
         return {
             "id": self.id,
+            "tenant_id": self.tenant_id,
             "customer_id": self.customer_id,
             "provider": self.provider,
             "raw_data_json": self.raw_data_json or {},

--- a/src/models/enrichment.py
+++ b/src/models/enrichment.py
@@ -1,6 +1,6 @@
 """Pydantic request / response schemas for the enrichment API."""
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 
 class EnrichmentLookupRequest(BaseModel):
@@ -8,6 +8,13 @@ class EnrichmentLookupRequest(BaseModel):
 
     domain: str | None = None
     company_name: str | None = None
+
+    @field_validator("domain", "company_name")
+    @classmethod
+    def strip_whitespace(cls, v: str | None) -> str | None:
+        if v is not None:
+            v = v.strip()
+        return v if v else None
 
     @model_validator(mode="after")
     def require_exactly_one(self) -> "EnrichmentLookupRequest":

--- a/src/models/enrichment.py
+++ b/src/models/enrichment.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, field_validator, model_validator
 class EnrichmentLookupRequest(BaseModel):
     """Request body for ``POST /api/v1/enrichment/lookup``."""
 
+    customer_id: int
     domain: str | None = None
     company_name: str | None = None
 

--- a/src/models/enrichment.py
+++ b/src/models/enrichment.py
@@ -15,11 +15,21 @@ class EnrichmentLookupRequest(BaseModel):
     def strip_whitespace(cls, v: str | None) -> str | None:
         if v is not None:
             v = v.strip()
-        return v if v else None
+        return v
 
     @model_validator(mode="after")
     def require_exactly_one(self) -> "EnrichmentLookupRequest":
-        active = [x for x in (self.domain, self.company_name) if x is not None]
+        # Use raw (pre-validator) values so '' is distinguishable from absent.
+        # __pydantic_extra__ is avoided; access via object.__dict__ to bypass the
+        # to-python strip that the field validator already applied.
+        raw_domain: str | None = object.__getattribute__(self, "domain")
+        raw_name: str | None = object.__getattribute__(self, "company_name")
+        # Restore stripped value for the active check.
+        active = [
+            x.strip() if isinstance(x, str) else None
+            for x in (raw_domain, raw_name)
+            if x is not None and x != ""
+        ]
         if len(active) != 1:
             raise ValueError("Provide exactly one of domain or company_name")
         return self

--- a/src/models/enrichment.py
+++ b/src/models/enrichment.py
@@ -1,0 +1,10 @@
+"""Pydantic request / response schemas for the enrichment API."""
+
+from pydantic import BaseModel
+
+
+class EnrichmentLookupRequest(BaseModel):
+    """Request body for ``POST /api/v1/enrichment/lookup``."""
+
+    domain: str | None = None
+    company_name: str | None = None

--- a/src/models/enrichment.py
+++ b/src/models/enrichment.py
@@ -1,6 +1,6 @@
 """Pydantic request / response schemas for the enrichment API."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class EnrichmentLookupRequest(BaseModel):
@@ -8,3 +8,10 @@ class EnrichmentLookupRequest(BaseModel):
 
     domain: str | None = None
     company_name: str | None = None
+
+    @model_validator(mode="after")
+    def require_exactly_one(self) -> "EnrichmentLookupRequest":
+        active = [x for x in (self.domain, self.company_name) if x is not None]
+        if len(active) != 1:
+            raise ValueError("Provide exactly one of domain or company_name")
+        return self

--- a/src/services/enrichment_service.py
+++ b/src/services/enrichment_service.py
@@ -17,7 +17,14 @@ class EnrichmentService:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def lookup(self, domain: str | None = None, company_name: str | None = None) -> dict[str, Any]:
+    async def lookup(
+        self,
+        domain: str | None = None,
+        company_name: str | None = None,
+        *,
+        tenant_id: int | None = None,
+        customer_id: int | None = None,
+    ) -> dict[str, Any]:
         """Look up company enrichment data from a third-party provider.
 
         Requires exactly one of *domain* or *company_name*.
@@ -30,9 +37,19 @@ class EnrichmentService:
         if has_domain == has_name:
             raise ValidationException("Provide exactly one of domain or company_name")
 
-        return await self._lookup_clearbit(domain=domain, company_name=company_name)
+        if customer_id is None:
+            raise ValidationException("customer_id is required for enrichment lookup")
 
-    async def _lookup_clearbit(self, domain: str | None, company_name: str | None) -> dict[str, Any]:
+        return await self._lookup_clearbit(
+            domain=domain,
+            company_name=company_name,
+            tenant_id=tenant_id,
+            customer_id=customer_id,
+        )
+
+    async def _lookup_clearbit(
+        self, domain: str | None, company_name: str | None, tenant_id: int | None, customer_id: int
+    ) -> dict[str, Any]:
         api_key = settings.clearbit_api_key
         if not api_key:
             raise ValidationException("Clearbit API key is not configured")
@@ -43,13 +60,15 @@ class EnrichmentService:
         else:
             params["name"] = company_name  # type: ignore[assignment]
 
-        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0)) as client:
             response = await client.get(
                 "https://company.clearbit.com/v2/companies/find",
                 params=params,
                 headers={"Authorization": f"Bearer {api_key}"},
             )
 
+        if response.status_code == 404:
+            return {}
         if not response.is_success:
             raise ValidationException("Clearbit API error")
 
@@ -59,7 +78,7 @@ class EnrichmentService:
         # Persist raw payload
         now = datetime.now(UTC)
         enrichment = CustomerEnrichmentModel(
-            customer_id=0,  # null until wired to a customer
+            customer_id=customer_id,
             provider="clearbit",
             raw_data_json=raw_data,
             enriched_at=now,

--- a/src/services/enrichment_service.py
+++ b/src/services/enrichment_service.py
@@ -58,20 +58,19 @@ class EnrichmentService:
         )
 
     async def _lookup_clearbit(
-        self, domain: str | None, company_name: str | None, tenant_id: int | None, customer_id: int
+        self, domain: str | None, company_name: str | None, tenant_id: int, customer_id: int
     ) -> dict[str, Any]:
         # Verify customer belongs to the requesting tenant
-        if customer_id is not None:
-            result = await self.session.execute(
-                select(CustomerModel).where(
-                    and_(CustomerModel.id == customer_id, CustomerModel.tenant_id == tenant_id)
-                )
+        result = await self.session.execute(
+            select(CustomerModel).where(
+                and_(CustomerModel.id == customer_id, CustomerModel.tenant_id == tenant_id)
             )
-            customer = result.scalar_one_or_none()
-            if customer is None:
-                raise NotFoundException("Customer")
+        )
+        customer = result.scalar_one_or_none()
+        if customer is None:
+            raise NotFoundException("Customer")
 
-        api_key = settings.clearbit_api_key
+        api_key: str = settings.clearbit_api_key
         if not api_key:
             raise ValidationException("Clearbit API key is not configured")
 
@@ -82,7 +81,10 @@ class EnrichmentService:
             params["name"] = company_name.strip()  # type: ignore[arg-type]
 
         async with httpx.AsyncClient(
-            timeout=httpx.Timeout(settings.clearbit_read_timeout, connect=settings.clearbit_connect_timeout)
+            timeout=httpx.Timeout(
+                settings.clearbit_read_timeout,
+                connect=settings.clearbit_connect_timeout or 5.0,
+            )
         ) as client:
             response = await client.get(
                 "https://company.clearbit.com/v2/companies/find",

--- a/src/services/enrichment_service.py
+++ b/src/services/enrichment_service.py
@@ -61,7 +61,7 @@ class EnrichmentService:
         self, domain: str | None, company_name: str | None, tenant_id: int | None, customer_id: int
     ) -> dict[str, Any]:
         # Verify customer belongs to the requesting tenant
-        if tenant_id is not None and customer_id is not None:
+        if customer_id is not None:
             result = await self.session.execute(
                 select(CustomerModel).where(
                     and_(CustomerModel.id == customer_id, CustomerModel.tenant_id == tenant_id)
@@ -100,6 +100,7 @@ class EnrichmentService:
 
         # Persist raw payload
         enrichment = CustomerEnrichmentModel(
+            tenant_id=tenant_id,
             customer_id=customer_id,
             provider="clearbit",
             raw_data_json=raw_data,

--- a/src/services/enrichment_service.py
+++ b/src/services/enrichment_service.py
@@ -1,0 +1,97 @@
+"""Enrichment service — third-party company data enrichment via Clearbit."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from configs.settings import settings
+from db.models.customer_enrichment import CustomerEnrichmentModel
+from pkg.errors.app_exceptions import ValidationException
+
+
+class EnrichmentService:
+    """Third-party company data enrichment."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def lookup(self, domain: str | None = None, company_name: str | None = None) -> dict[str, Any]:
+        """Look up company enrichment data from a third-party provider.
+
+        Requires exactly one of *domain* or *company_name*.
+        Persists the raw provider payload to ``customer_enrichments`` and returns
+        a normalised dict of enriched fields.
+        """
+        has_domain = domain is not None
+        has_name = company_name is not None
+
+        if has_domain == has_name:
+            raise ValidationException("Provide exactly one of domain or company_name")
+
+        return await self._lookup_clearbit(domain=domain, company_name=company_name)
+
+    async def _lookup_clearbit(self, domain: str | None, company_name: str | None) -> dict[str, Any]:
+        api_key = settings.clearbit_api_key
+        if not api_key:
+            raise ValidationException("Clearbit API key is not configured")
+
+        params: dict[str, str] = {}
+        if domain:
+            params["domain"] = domain
+        else:
+            params["name"] = company_name  # type: ignore[assignment]
+
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+            response = await client.get(
+                "https://company.clearbit.com/v2/companies/find",
+                params=params,
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+
+        if not response.is_success:
+            raise ValidationException("Clearbit API error")
+
+        raw_data: dict[str, Any] = response.json()
+        normalised = self._normalise_clearbit(raw_data)
+
+        # Persist raw payload
+        now = datetime.now(UTC)
+        enrichment = CustomerEnrichmentModel(
+            customer_id=0,  # null until wired to a customer
+            provider="clearbit",
+            raw_data_json=raw_data,
+            enriched_at=now,
+        )
+        self.session.add(enrichment)
+        await self.session.flush()
+
+        return normalised
+
+    def _normalise_clearbit(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Flatten a Clearbit company payload into a portable dict.
+
+        Only includes keys that are present and non-null.
+        """
+        out: dict[str, Any] = {}
+
+        for key in ("name", "domain", "legalName", "category", "logo", "linkedin"):
+            if key in data and data[key] is not None:
+                # remap legalName -> legal_name
+                normalised_key = key.replace("legalName", "legal_name")
+                out[normalised_key] = data[key]
+
+        geo = data.get("geo")
+        if isinstance(geo, dict):
+            for sub in ("city", "state", "country", "countryCode"):
+                if sub in geo and geo[sub] is not None:
+                    out[f"geo_{sub}"] = geo[sub]
+
+        metrics = data.get("metrics")
+        if isinstance(metrics, dict):
+            for sub in ("employees", "employeesRange", "annualRevenue", "raised"):
+                if sub in metrics and metrics[sub] is not None:
+                    out[f"metrics_{sub}"] = metrics[sub]
+
+        return out

--- a/src/services/enrichment_service.py
+++ b/src/services/enrichment_service.py
@@ -1,6 +1,5 @@
 """Enrichment service — third-party company data enrichment via Clearbit."""
 
-from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -22,7 +21,6 @@ class EnrichmentService:
         domain: str | None = None,
         company_name: str | None = None,
         *,
-        tenant_id: int | None = None,
         customer_id: int | None = None,
     ) -> dict[str, Any]:
         """Look up company enrichment data from a third-party provider.
@@ -43,12 +41,11 @@ class EnrichmentService:
         return await self._lookup_clearbit(
             domain=domain,
             company_name=company_name,
-            tenant_id=tenant_id,
             customer_id=customer_id,
         )
 
     async def _lookup_clearbit(
-        self, domain: str | None, company_name: str | None, tenant_id: int | None, customer_id: int
+        self, domain: str | None, company_name: str | None, customer_id: int
     ) -> dict[str, Any]:
         api_key = settings.clearbit_api_key
         if not api_key:
@@ -60,7 +57,9 @@ class EnrichmentService:
         else:
             params["name"] = company_name  # type: ignore[assignment]
 
-        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0)) as client:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(settings.clearbit_read_timeout, connect=settings.clearbit_connect_timeout)
+        ) as client:
             response = await client.get(
                 "https://company.clearbit.com/v2/companies/find",
                 params=params,
@@ -76,12 +75,10 @@ class EnrichmentService:
         normalised = self._normalise_clearbit(raw_data)
 
         # Persist raw payload
-        now = datetime.now(UTC)
         enrichment = CustomerEnrichmentModel(
             customer_id=customer_id,
             provider="clearbit",
             raw_data_json=raw_data,
-            enriched_at=now,
         )
         self.session.add(enrichment)
         await self.session.flush()

--- a/src/services/enrichment_service.py
+++ b/src/services/enrichment_service.py
@@ -1,13 +1,16 @@
 """Enrichment service — third-party company data enrichment via Clearbit."""
 
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from configs.settings import settings
+from db.models.customer import CustomerModel
 from db.models.customer_enrichment import CustomerEnrichmentModel
-from pkg.errors.app_exceptions import ValidationException
+from pkg.errors.app_exceptions import NotFoundException, ValidationException
 
 
 class EnrichmentService:
@@ -21,6 +24,7 @@ class EnrichmentService:
         domain: str | None = None,
         company_name: str | None = None,
         *,
+        tenant_id: int | None = None,
         customer_id: int | None = None,
     ) -> dict[str, Any]:
         """Look up company enrichment data from a third-party provider.
@@ -29,6 +33,14 @@ class EnrichmentService:
         Persists the raw provider payload to ``customer_enrichments`` and returns
         a normalised dict of enriched fields.
         """
+        # Normalise: treat blank strings as absent
+        if domain is not None:
+            domain = domain.strip()
+            domain = domain if domain else None
+        if company_name is not None:
+            company_name = company_name.strip()
+            company_name = company_name if company_name else None
+
         has_domain = domain is not None
         has_name = company_name is not None
 
@@ -41,21 +53,33 @@ class EnrichmentService:
         return await self._lookup_clearbit(
             domain=domain,
             company_name=company_name,
+            tenant_id=tenant_id,
             customer_id=customer_id,
         )
 
     async def _lookup_clearbit(
-        self, domain: str | None, company_name: str | None, customer_id: int
+        self, domain: str | None, company_name: str | None, tenant_id: int | None, customer_id: int
     ) -> dict[str, Any]:
+        # Verify customer belongs to the requesting tenant
+        if tenant_id is not None and customer_id is not None:
+            result = await self.session.execute(
+                select(CustomerModel).where(
+                    and_(CustomerModel.id == customer_id, CustomerModel.tenant_id == tenant_id)
+                )
+            )
+            customer = result.scalar_one_or_none()
+            if customer is None:
+                raise NotFoundException("Customer")
+
         api_key = settings.clearbit_api_key
         if not api_key:
             raise ValidationException("Clearbit API key is not configured")
 
         params: dict[str, str] = {}
         if domain:
-            params["domain"] = domain
+            params["domain"] = domain.strip()
         else:
-            params["name"] = company_name  # type: ignore[assignment]
+            params["name"] = company_name.strip()  # type: ignore[arg-type]
 
         async with httpx.AsyncClient(
             timeout=httpx.Timeout(settings.clearbit_read_timeout, connect=settings.clearbit_connect_timeout)
@@ -67,9 +91,9 @@ class EnrichmentService:
             )
 
         if response.status_code == 404:
-            return {}
+            raise ValidationException("No company found for the given domain or name")
         if not response.is_success:
-            raise ValidationException("Clearbit API error")
+            raise ValidationException(f"Clearbit API error: {response.status_code}")
 
         raw_data: dict[str, Any] = response.json()
         normalised = self._normalise_clearbit(raw_data)
@@ -79,6 +103,7 @@ class EnrichmentService:
             customer_id=customer_id,
             provider="clearbit",
             raw_data_json=raw_data,
+            enriched_at=datetime.now(UTC),
         )
         self.session.add(enrichment)
         await self.session.flush()

--- a/tests/unit/test_enrichment_router.py
+++ b/tests/unit/test_enrichment_router.py
@@ -91,13 +91,20 @@ class TestLookupEndpoint:
 
     def test_validation_exception_returns_422(self, client_with_service):
         client, svc = client_with_service
-        svc.lookup = AsyncMock(side_effect=ValidationException("exactly one"))
+        svc.lookup = AsyncMock(side_effect=ValidationException("service-level validation"))
 
-        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={})
+        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
         assert resp.status_code == 422
         body = resp.json()
         assert body["success"] is False
-        assert "exactly one" in body["message"]
+        assert "service-level validation" in body["message"]
+
+    def test_model_validator_rejects_both_fields(self, client_with_service):
+        client, _svc = client_with_service
+        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com", "company_name": "Stripe"})
+        assert resp.status_code == 422
+        body = resp.json()
+        assert "Provide exactly one of domain or company_name" in body["detail"][0]["msg"]
 
     def test_clearbit_api_error_returns_422(self, client_with_service):
         client, svc = client_with_service
@@ -113,14 +120,14 @@ class TestLookupEndpoint:
         svc.lookup = AsyncMock(return_value={"name": "Stripe"})
 
         client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
-        svc.lookup.assert_awaited_once_with(domain="stripe.com", company_name=None, tenant_id=1, customer_id=42)
+        svc.lookup.assert_awaited_once_with(domain="stripe.com", company_name=None, customer_id=42)
 
     def test_passes_company_name_to_service(self, client_with_service):
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Acme Corp"})
 
         client.post("/api/v1/enrichment/lookup?customer_id=42", json={"company_name": "Acme Corp"})
-        svc.lookup.assert_awaited_once_with(domain=None, company_name="Acme Corp", tenant_id=1, customer_id=42)
+        svc.lookup.assert_awaited_once_with(domain=None, company_name="Acme Corp", customer_id=42)
 
     def test_success_response_has_envelope_shape(self, client_with_service):
         client, svc = client_with_service

--- a/tests/unit/test_enrichment_router.py
+++ b/tests/unit/test_enrichment_router.py
@@ -145,3 +145,4 @@ class TestLookupEndpoint:
         assert "success" in body
         assert "data" in body
         assert "message" in body
+        assert isinstance(body["message"], str)

--- a/tests/unit/test_enrichment_router.py
+++ b/tests/unit/test_enrichment_router.py
@@ -12,6 +12,7 @@ from api.routers.enrichment import enrichment_router
 from internal.middleware.fastapi_auth import AuthContext
 from db.connection import get_db
 from pkg.errors.app_exceptions import AppException, ValidationException
+from tests.unit.conftest import make_mock_session
 
 
 # ---------------------------------------------------------------------------
@@ -24,13 +25,14 @@ def _make_auth_ctx(tenant_id: int = 1, user_id: int = 99) -> AuthContext:
 
 @pytest.fixture
 def mock_db_session():
-    return MagicMock()
+    return make_mock_session(handlers=[])
 
 
 @pytest.fixture
 def client_with_service(monkeypatch, mock_db_session):
     """Return a TestClient with EnrichmentService fully mocked."""
     from internal.middleware.fastapi_auth import require_auth
+    from services.enrichment_service import EnrichmentService
 
     mock_service = MagicMock()
 
@@ -71,7 +73,7 @@ class TestLookupEndpoint:
             }
         )
 
-        resp = client.post("/api/v1/enrichment/lookup", json={"domain": "stripe.com"})
+        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
         assert resp.status_code == 200
         body = resp.json()
         assert body["success"] is True
@@ -82,7 +84,7 @@ class TestLookupEndpoint:
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Acme Corp", "domain": "acme.com"})
 
-        resp = client.post("/api/v1/enrichment/lookup", json={"company_name": "Acme Corp"})
+        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"company_name": "Acme Corp"})
         assert resp.status_code == 200
         body = resp.json()
         assert body["success"] is True
@@ -91,7 +93,7 @@ class TestLookupEndpoint:
         client, svc = client_with_service
         svc.lookup = AsyncMock(side_effect=ValidationException("exactly one"))
 
-        resp = client.post("/api/v1/enrichment/lookup", json={})
+        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={})
         assert resp.status_code == 422
         body = resp.json()
         assert body["success"] is False
@@ -101,7 +103,7 @@ class TestLookupEndpoint:
         client, svc = client_with_service
         svc.lookup = AsyncMock(side_effect=ValidationException("Clearbit API error"))
 
-        resp = client.post("/api/v1/enrichment/lookup", json={"domain": "notfound.com"})
+        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "notfound.com"})
         assert resp.status_code == 422
         body = resp.json()
         assert "Clearbit API error" in body["message"]
@@ -110,21 +112,21 @@ class TestLookupEndpoint:
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Stripe"})
 
-        client.post("/api/v1/enrichment/lookup", json={"domain": "stripe.com"})
-        svc.lookup.assert_awaited_once_with(domain="stripe.com", company_name=None)
+        client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
+        svc.lookup.assert_awaited_once_with(domain="stripe.com", company_name=None, tenant_id=1, customer_id=42)
 
     def test_passes_company_name_to_service(self, client_with_service):
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Acme Corp"})
 
-        client.post("/api/v1/enrichment/lookup", json={"company_name": "Acme Corp"})
-        svc.lookup.assert_awaited_once_with(domain=None, company_name="Acme Corp")
+        client.post("/api/v1/enrichment/lookup?customer_id=42", json={"company_name": "Acme Corp"})
+        svc.lookup.assert_awaited_once_with(domain=None, company_name="Acme Corp", tenant_id=1, customer_id=42)
 
     def test_success_response_has_envelope_shape(self, client_with_service):
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Stripe", "domain": "stripe.com"})
 
-        resp = client.post("/api/v1/enrichment/lookup", json={"domain": "stripe.com"})
+        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
         body = resp.json()
         assert "success" in body
         assert "data" in body

--- a/tests/unit/test_enrichment_router.py
+++ b/tests/unit/test_enrichment_router.py
@@ -74,7 +74,7 @@ class TestLookupEndpoint:
             }
         )
 
-        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
+        resp = client.post("/api/v1/enrichment/lookup", json={"customer_id": 42, "domain": "stripe.com"})
         assert resp.status_code == 200
         body = resp.json()
         assert body["success"] is True
@@ -85,7 +85,7 @@ class TestLookupEndpoint:
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Acme Corp", "domain": "acme.com"})
 
-        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"company_name": "Acme Corp"})
+        resp = client.post("/api/v1/enrichment/lookup", json={"customer_id": 42, "company_name": "Acme Corp"})
         assert resp.status_code == 200
         body = resp.json()
         assert body["success"] is True
@@ -94,7 +94,7 @@ class TestLookupEndpoint:
         client, svc = client_with_service
         svc.lookup = AsyncMock(side_effect=ValidationException("service-level validation"))
 
-        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
+        resp = client.post("/api/v1/enrichment/lookup", json={"customer_id": 42, "domain": "stripe.com"})
         assert resp.status_code == 422
         body = resp.json()
         assert body["success"] is False
@@ -102,16 +102,14 @@ class TestLookupEndpoint:
 
     def test_model_validator_rejects_both_fields(self, client_with_service):
         client, _svc = client_with_service
-        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com", "company_name": "Stripe"})
+        resp = client.post("/api/v1/enrichment/lookup", json={"customer_id": 42, "domain": "stripe.com", "company_name": "Stripe"})
         assert resp.status_code == 422
         body = resp.json()
         assert "Provide exactly one of domain or company_name" in body["detail"][0]["msg"]
 
-    def test_missing_customer_id_raises_validation(self, client_with_service):
-        """When customer_id is absent from the query string the service raises ValidationException."""
-        client, svc = client_with_service
-        svc.lookup = AsyncMock(side_effect=ValidationException("customer_id is required for enrichment lookup"))
-
+    def test_missing_customer_id_raises_422(self, client_with_service):
+        """When customer_id is absent from the request body FastAPI returns 422."""
+        client, _svc = client_with_service
         resp = client.post("/api/v1/enrichment/lookup", json={"domain": "stripe.com"})
         assert resp.status_code == 422
 
@@ -119,7 +117,7 @@ class TestLookupEndpoint:
         client, svc = client_with_service
         svc.lookup = AsyncMock(side_effect=ValidationException("Clearbit API error: 404"))
 
-        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "notfound.com"})
+        resp = client.post("/api/v1/enrichment/lookup", json={"customer_id": 42, "domain": "notfound.com"})
         assert resp.status_code == 422
         body = resp.json()
         assert "Clearbit API error" in body["message"]
@@ -128,21 +126,21 @@ class TestLookupEndpoint:
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Stripe"})
 
-        client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
+        client.post("/api/v1/enrichment/lookup", json={"customer_id": 42, "domain": "stripe.com"})
         svc.lookup.assert_awaited_once_with(domain="stripe.com", company_name=None, tenant_id=1, customer_id=42)
 
     def test_passes_company_name_to_service(self, client_with_service):
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Acme Corp"})
 
-        client.post("/api/v1/enrichment/lookup?customer_id=42", json={"company_name": "Acme Corp"})
+        client.post("/api/v1/enrichment/lookup", json={"customer_id": 42, "company_name": "Acme Corp"})
         svc.lookup.assert_awaited_once_with(domain=None, company_name="Acme Corp", tenant_id=1, customer_id=42)
 
     def test_success_response_has_envelope_shape(self, client_with_service):
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Stripe", "domain": "stripe.com"})
 
-        resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
+        resp = client.post("/api/v1/enrichment/lookup", json={"customer_id": 42, "domain": "stripe.com"})
         body = resp.json()
         assert "success" in body
         assert "data" in body

--- a/tests/unit/test_enrichment_router.py
+++ b/tests/unit/test_enrichment_router.py
@@ -25,6 +25,7 @@ def _make_auth_ctx(tenant_id: int = 1, user_id: int = 99) -> AuthContext:
 
 @pytest.fixture
 def mock_db_session():
+    # Router delegates to service; no DB queries needed in this fixture.
     return make_mock_session(handlers=[])
 
 
@@ -106,9 +107,17 @@ class TestLookupEndpoint:
         body = resp.json()
         assert "Provide exactly one of domain or company_name" in body["detail"][0]["msg"]
 
+    def test_missing_customer_id_raises_validation(self, client_with_service):
+        """When customer_id is absent from the query string the service raises ValidationException."""
+        client, svc = client_with_service
+        svc.lookup = AsyncMock(side_effect=ValidationException("customer_id is required for enrichment lookup"))
+
+        resp = client.post("/api/v1/enrichment/lookup", json={"domain": "stripe.com"})
+        assert resp.status_code == 422
+
     def test_clearbit_api_error_returns_422(self, client_with_service):
         client, svc = client_with_service
-        svc.lookup = AsyncMock(side_effect=ValidationException("Clearbit API error"))
+        svc.lookup = AsyncMock(side_effect=ValidationException("Clearbit API error: 404"))
 
         resp = client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "notfound.com"})
         assert resp.status_code == 422
@@ -120,14 +129,14 @@ class TestLookupEndpoint:
         svc.lookup = AsyncMock(return_value={"name": "Stripe"})
 
         client.post("/api/v1/enrichment/lookup?customer_id=42", json={"domain": "stripe.com"})
-        svc.lookup.assert_awaited_once_with(domain="stripe.com", company_name=None, customer_id=42)
+        svc.lookup.assert_awaited_once_with(domain="stripe.com", company_name=None, tenant_id=1, customer_id=42)
 
     def test_passes_company_name_to_service(self, client_with_service):
         client, svc = client_with_service
         svc.lookup = AsyncMock(return_value={"name": "Acme Corp"})
 
         client.post("/api/v1/enrichment/lookup?customer_id=42", json={"company_name": "Acme Corp"})
-        svc.lookup.assert_awaited_once_with(domain=None, company_name="Acme Corp", customer_id=42)
+        svc.lookup.assert_awaited_once_with(domain=None, company_name="Acme Corp", tenant_id=1, customer_id=42)
 
     def test_success_response_has_envelope_shape(self, client_with_service):
         client, svc = client_with_service

--- a/tests/unit/test_enrichment_router.py
+++ b/tests/unit/test_enrichment_router.py
@@ -1,0 +1,131 @@
+"""Unit tests for src/api/routers/enrichment.py."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from api.routers.enrichment import enrichment_router
+from internal.middleware.fastapi_auth import AuthContext
+from db.connection import get_db
+from pkg.errors.app_exceptions import AppException, ValidationException
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_auth_ctx(tenant_id: int = 1, user_id: int = 99) -> AuthContext:
+    return AuthContext(user_id=user_id, tenant_id=tenant_id, roles=[])
+
+
+@pytest.fixture
+def mock_db_session():
+    return MagicMock()
+
+
+@pytest.fixture
+def client_with_service(monkeypatch, mock_db_session):
+    """Return a TestClient with EnrichmentService fully mocked."""
+    from internal.middleware.fastapi_auth import require_auth
+
+    mock_service = MagicMock()
+
+    monkeypatch.setattr(
+        "api.routers.enrichment.EnrichmentService",
+        lambda session: mock_service,
+    )
+
+    app = FastAPI()
+    app.include_router(enrichment_router)
+    app.dependency_overrides[require_auth] = lambda: _make_auth_ctx()
+    app.dependency_overrides[get_db] = lambda: mock_db_session
+
+    @app.exception_handler(AppException)
+    async def app_exception_handler(request: Request, exc: AppException) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"success": False, "message": exc.detail, "code": exc.code},
+        )
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, mock_service
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/enrichment/lookup
+# ---------------------------------------------------------------------------
+
+class TestLookupEndpoint:
+    def test_returns_enriched_data_on_success(self, client_with_service):
+        client, svc = client_with_service
+        svc.lookup = AsyncMock(
+            return_value={
+                "name": "Stripe",
+                "domain": "stripe.com",
+                "geo_city": "San Francisco",
+                "metrics_employees": 8000,
+            }
+        )
+
+        resp = client.post("/api/v1/enrichment/lookup", json={"domain": "stripe.com"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"]["name"] == "Stripe"
+        assert body["data"]["domain"] == "stripe.com"
+
+    def test_uses_company_name(self, client_with_service):
+        client, svc = client_with_service
+        svc.lookup = AsyncMock(return_value={"name": "Acme Corp", "domain": "acme.com"})
+
+        resp = client.post("/api/v1/enrichment/lookup", json={"company_name": "Acme Corp"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+
+    def test_validation_exception_returns_422(self, client_with_service):
+        client, svc = client_with_service
+        svc.lookup = AsyncMock(side_effect=ValidationException("exactly one"))
+
+        resp = client.post("/api/v1/enrichment/lookup", json={})
+        assert resp.status_code == 422
+        body = resp.json()
+        assert body["success"] is False
+        assert "exactly one" in body["message"]
+
+    def test_clearbit_api_error_returns_422(self, client_with_service):
+        client, svc = client_with_service
+        svc.lookup = AsyncMock(side_effect=ValidationException("Clearbit API error"))
+
+        resp = client.post("/api/v1/enrichment/lookup", json={"domain": "notfound.com"})
+        assert resp.status_code == 422
+        body = resp.json()
+        assert "Clearbit API error" in body["message"]
+
+    def test_passes_domain_to_service(self, client_with_service):
+        client, svc = client_with_service
+        svc.lookup = AsyncMock(return_value={"name": "Stripe"})
+
+        client.post("/api/v1/enrichment/lookup", json={"domain": "stripe.com"})
+        svc.lookup.assert_awaited_once_with(domain="stripe.com", company_name=None)
+
+    def test_passes_company_name_to_service(self, client_with_service):
+        client, svc = client_with_service
+        svc.lookup = AsyncMock(return_value={"name": "Acme Corp"})
+
+        client.post("/api/v1/enrichment/lookup", json={"company_name": "Acme Corp"})
+        svc.lookup.assert_awaited_once_with(domain=None, company_name="Acme Corp")
+
+    def test_success_response_has_envelope_shape(self, client_with_service):
+        client, svc = client_with_service
+        svc.lookup = AsyncMock(return_value={"name": "Stripe", "domain": "stripe.com"})
+
+        resp = client.post("/api/v1/enrichment/lookup", json={"domain": "stripe.com"})
+        body = resp.json()
+        assert "success" in body
+        assert "data" in body
+        assert "message" in body

--- a/tests/unit/test_enrichment_service.py
+++ b/tests/unit/test_enrichment_service.py
@@ -1,0 +1,259 @@
+"""Unit tests for src/services/enrichment_service.py."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pkg.errors.app_exceptions import ValidationException
+from services.enrichment_service import EnrichmentService
+
+
+# ---------------------------------------------------------------------------
+# Mock session
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_db_session():
+    session = MagicMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def service(mock_db_session):
+    return EnrichmentService(mock_db_session)
+
+
+# ---------------------------------------------------------------------------
+# lookup — argument validation
+# ---------------------------------------------------------------------------
+
+class TestLookupArgumentValidation:
+    async def test_neither_domain_nor_name_raises(self, service):
+        with pytest.raises(ValidationException) as exc_info:
+            await service.lookup(domain=None, company_name=None)
+        assert "exactly one" in exc_info.value.detail
+
+    async def test_both_domain_and_name_raises(self, service):
+        with pytest.raises(ValidationException) as exc_info:
+            await service.lookup(domain="stripe.com", company_name="Stripe")
+        assert "exactly one" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# lookup — HTTP client mock factory
+# ---------------------------------------------------------------------------
+
+async def _make_http_response(is_success: bool, data: dict) -> MagicMock:
+    """Return a mock httpx response matching httpx 0.28.x sync Response.json()."""
+    mock_resp = MagicMock()
+    mock_resp.is_success = is_success
+    mock_resp.status_code = 500 if not is_success else 200
+    mock_resp.json = MagicMock(return_value=data)
+    return mock_resp
+
+
+# ---------------------------------------------------------------------------
+# lookup — domain path (success)
+# ---------------------------------------------------------------------------
+
+class TestLookupDomainSuccess:
+    async def test_returns_normalised_dict(self, service, mock_db_session):
+        clearbit_payload = {
+            "name": "Stripe",
+            "domain": "stripe.com",
+            "legalName": "Stripe, Inc.",
+            "category": {"sector": "Software", "industryGroup": "IT"},
+            "logo": "https://logo.clearbit.com/stripe.com/logo.png",
+            "linkedin": {"handle": "company/stripe"},
+            "geo": {"city": "San Francisco", "state": "CA", "country": "US", "countryCode": "US"},
+            "metrics": {
+                "employees": 8000,
+                "employeesRange": "5000+",
+                "annualRevenue": "1000000000",
+                "raised": 2000000,
+            },
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.is_success = True
+        mock_resp.json = MagicMock(return_value=clearbit_payload)
+        mock_get = AsyncMock(return_value=mock_resp)
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = mock_get
+
+        with patch("services.enrichment_service.settings") as mock_settings, \
+             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client) as mock_client_cls:
+            mock_settings.clearbit_api_key = "test-key"
+            result = await service.lookup(domain="stripe.com")
+
+        assert result["name"] == "Stripe"
+        assert result["domain"] == "stripe.com"
+        assert result["legal_name"] == "Stripe, Inc."
+        assert result["geo_city"] == "San Francisco"
+        assert result["metrics_employees"] == 8000
+
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args.kwargs
+        assert call_kwargs["params"]["domain"] == "stripe.com"
+
+        mock_db_session.add.assert_called_once()
+        added = mock_db_session.add.call_args[0][0]
+        assert added.provider == "clearbit"
+        assert added.raw_data_json == clearbit_payload
+
+    async def test_inserts_enrichment_row(self, service, mock_db_session):
+        mock_resp = MagicMock()
+        mock_resp.is_success = True
+        mock_resp.json = MagicMock(return_value={"name": "Acme", "domain": "acme.com"})
+        mock_get = AsyncMock(return_value=mock_resp)
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = mock_get
+
+        with patch("services.enrichment_service.settings") as mock_settings, \
+             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
+            mock_settings.clearbit_api_key = "test-key"
+            await service.lookup(domain="acme.com")
+
+        mock_db_session.add.assert_called_once()
+        added = mock_db_session.add.call_args[0][0]
+        assert added.customer_id == 0
+        assert added.provider == "clearbit"
+        mock_db_session.flush.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# lookup — company_name path (success)
+# ---------------------------------------------------------------------------
+
+class TestLookupCompanyNameSuccess:
+    async def test_uses_name_param(self, service, mock_db_session):
+        mock_resp = MagicMock()
+        mock_resp.is_success = True
+        mock_resp.json = MagicMock(return_value={"name": "Acme Corp", "domain": "acme.com"})
+        mock_get = AsyncMock(return_value=mock_resp)
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = mock_get
+
+        with patch("services.enrichment_service.settings") as mock_settings, \
+             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
+            mock_settings.clearbit_api_key = "test-key"
+            result = await service.lookup(company_name="Acme Corp")
+
+        call_kwargs = mock_client.get.call_args
+        assert call_kwargs.kwargs["params"]["name"] == "Acme Corp"
+        assert result["name"] == "Acme Corp"
+
+
+# ---------------------------------------------------------------------------
+# lookup — HTTP error cases
+# ---------------------------------------------------------------------------
+
+class TestLookupHttpErrors:
+    async def test_http_404_raises_validation_exception(self, service):
+        mock_resp = MagicMock()
+        mock_resp.is_success = False
+        mock_resp.status_code = 404
+        mock_resp.json = MagicMock(return_value={})
+        mock_get = AsyncMock(return_value=mock_resp)
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = mock_get
+
+        with patch("services.enrichment_service.settings") as mock_settings, \
+             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
+            mock_settings.clearbit_api_key = "test-key"
+            with pytest.raises(ValidationException) as exc_info:
+                await service.lookup(domain="notfound.example.com")
+        assert "Clearbit API error" in exc_info.value.detail
+
+    async def test_http_500_raises_validation_exception(self, service):
+        mock_resp = MagicMock()
+        mock_resp.is_success = False
+        mock_resp.status_code = 500
+        mock_resp.json = MagicMock(return_value={})
+        mock_get = AsyncMock(return_value=mock_resp)
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = mock_get
+
+        with patch("services.enrichment_service.settings") as mock_settings, \
+             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
+            mock_settings.clearbit_api_key = "test-key"
+            with pytest.raises(ValidationException) as exc_info:
+                await service.lookup(domain="stripe.com")
+        assert "Clearbit API error" in exc_info.value.detail
+
+    async def test_missing_api_key_raises(self, service):
+        with patch("services.enrichment_service.settings") as mock_settings:
+            mock_settings.clearbit_api_key = None
+
+            with pytest.raises(ValidationException) as exc_info:
+                await service.lookup(domain="stripe.com")
+            assert "not configured" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# _normalise_clearbit
+# ---------------------------------------------------------------------------
+
+class TestNormaliseClearbit:
+    def test_includes_present_keys(self, service):
+        data = {
+            "name": "Stripe",
+            "domain": "stripe.com",
+            "legalName": "Stripe, Inc.",
+            "logo": "https://logo.example.com/logo.png",
+            "linkedin": {"handle": "company/stripe"},
+        }
+        result = service._normalise_clearbit(data)
+        assert result["name"] == "Stripe"
+        assert result["domain"] == "stripe.com"
+        assert result["legal_name"] == "Stripe, Inc."
+        assert result["logo"] == "https://logo.example.com/logo.png"
+
+    def test_skips_null_values(self, service):
+        data = {"name": "Stripe", "domain": None}
+        result = service._normalise_clearbit(data)
+        assert "name" in result
+        assert "domain" not in result
+
+    def test_flattens_geo(self, service):
+        data = {
+            "name": "Stripe",
+            "geo": {"city": "San Francisco", "country": "US", "countryCode": "US"},
+        }
+        result = service._normalise_clearbit(data)
+        assert result["geo_city"] == "San Francisco"
+        assert result["geo_country"] == "US"
+        assert result["geo_countryCode"] == "US"
+
+    def test_flattens_metrics(self, service):
+        data = {
+            "name": "Stripe",
+            "metrics": {"employees": 8000, "annualRevenue": "1000000000", "raised": 2000000},
+        }
+        result = service._normalise_clearbit(data)
+        assert result["metrics_employees"] == 8000
+        assert result["metrics_annualRevenue"] == "1000000000"
+
+    def test_skips_missing_geo_and_metrics(self, service):
+        data = {"name": "Acme"}
+        result = service._normalise_clearbit(data)
+        assert "name" in result
+        assert "geo_city" not in result
+        assert "metrics_employees" not in result

--- a/tests/unit/test_enrichment_service.py
+++ b/tests/unit/test_enrichment_service.py
@@ -14,10 +14,11 @@ from services.enrichment_service import EnrichmentService
 
 @pytest.fixture
 def mock_db_session():
-    # Minimal mock covering add / flush / execute.
+    # Configure each mock explicitly to catch attribute typos (e.g. execute vs exceute).
     session = MagicMock()
     session.add = MagicMock()
     session.flush = AsyncMock()
+    session.execute = AsyncMock()
     return session
 
 
@@ -160,6 +161,7 @@ class TestLookupDomainSuccess:
         assert added.customer_id == 1
         assert added.tenant_id == 1
         assert added.provider == "clearbit"
+        assert added.raw_data_json == {"name": "Acme", "domain": "acme.com"}
         mock_db_session.flush.assert_awaited_once()
 
 

--- a/tests/unit/test_enrichment_service.py
+++ b/tests/unit/test_enrichment_service.py
@@ -132,7 +132,6 @@ class TestLookupDomainSuccess:
         assert added.customer_id == 1
         assert added.provider == "clearbit"
         mock_db_session.flush.assert_awaited_once()
-        mock_db_session.flush.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_enrichment_service.py
+++ b/tests/unit/test_enrichment_service.py
@@ -14,7 +14,7 @@ from services.enrichment_service import EnrichmentService
 
 @pytest.fixture
 def mock_db_session():
-    # Router delegates to service; no DB queries needed in this fixture.
+    # Minimal mock covering add / flush / execute.
     session = MagicMock()
     session.add = MagicMock()
     session.flush = AsyncMock()
@@ -130,6 +130,7 @@ class TestLookupDomainSuccess:
         added = mock_db_session.add.call_args[0][0]
         assert added.provider == "clearbit"
         assert added.raw_data_json == clearbit_payload
+        assert added.tenant_id == 42
 
     async def test_inserts_enrichment_row(self, service, mock_db_session):
         mock_resp = MagicMock()
@@ -157,6 +158,7 @@ class TestLookupDomainSuccess:
         mock_db_session.add.assert_called_once()
         added = mock_db_session.add.call_args[0][0]
         assert added.customer_id == 1
+        assert added.tenant_id == 1
         assert added.provider == "clearbit"
         mock_db_session.flush.assert_awaited_once()
 
@@ -211,27 +213,6 @@ class TestLookupCrossTenantIsolation:
             with pytest.raises(NotFoundException) as exc_info:
                 await service.lookup(domain="stripe.com", customer_id=1, tenant_id=999)
             assert "Customer" in exc_info.value.detail
-
-    async def test_lookup_without_tenant_id_skips_tenant_check(self, service, mock_db_session):
-        """When tenant_id is None, no customer lookup is performed."""
-        mock_resp = MagicMock()
-        mock_resp.is_success = True
-        mock_resp.json = MagicMock(return_value={"name": "Stripe", "domain": "stripe.com"})
-        mock_get = AsyncMock(return_value=mock_resp)
-
-        mock_client = MagicMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.get = mock_get
-
-        with patch("services.enrichment_service.settings") as mock_settings, \
-             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
-            mock_settings.clearbit_api_key = "test-key"
-            # tenant_id=None skips the customer lookup — no execute call
-            result = await service.lookup(domain="stripe.com", customer_id=1, tenant_id=None)
-
-        mock_db_session.execute.assert_not_called()
-        assert result["name"] == "Stripe"
 
 
 # ---------------------------------------------------------------------------
@@ -319,6 +300,13 @@ class TestLookupHttpErrors:
         assert "Clearbit API error: 503" in exc_info.value.detail
 
     async def test_missing_api_key_raises(self, service, mock_db_session):
+        mock_customer = MagicMock()
+        mock_customer.id = 1
+        mock_customer.tenant_id = 1
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_customer)
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
         with patch("services.enrichment_service.settings") as mock_settings:
             mock_settings.clearbit_api_key = None
 

--- a/tests/unit/test_enrichment_service.py
+++ b/tests/unit/test_enrichment_service.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from pkg.errors.app_exceptions import ValidationException
+from pkg.errors.app_exceptions import NotFoundException, ValidationException
 from services.enrichment_service import EnrichmentService
 
 
@@ -14,6 +14,7 @@ from services.enrichment_service import EnrichmentService
 
 @pytest.fixture
 def mock_db_session():
+    # Router delegates to service; no DB queries needed in this fixture.
     session = MagicMock()
     session.add = MagicMock()
     session.flush = AsyncMock()
@@ -45,16 +46,27 @@ class TestLookupArgumentValidation:
             await service.lookup(domain="stripe.com", customer_id=None)
         assert "customer_id" in exc_info.value.detail
 
+    async def test_blank_domain_treated_as_absent(self, service):
+        """domain='' should fall through to company_name check."""
+        with pytest.raises(ValidationException) as exc_info:
+            await service.lookup(domain="", company_name=None, customer_id=1)
+        assert "exactly one" in exc_info.value.detail
+
+    async def test_whitespace_only_domain_treated_as_absent(self, service):
+        with pytest.raises(ValidationException) as exc_info:
+            await service.lookup(domain="   ", company_name=None, customer_id=1)
+        assert "exactly one" in exc_info.value.detail
+
 
 # ---------------------------------------------------------------------------
 # lookup — HTTP client mock factory
 # ---------------------------------------------------------------------------
 
-def _make_http_response(is_success: bool, data: dict) -> MagicMock:
+def _make_http_response(is_success: bool, status_code: int, data: dict) -> MagicMock:
     """Return a mock httpx response matching httpx 0.28.x sync Response.json()."""
     mock_resp = MagicMock()
     mock_resp.is_success = is_success
-    mock_resp.status_code = 500 if not is_success else 200
+    mock_resp.status_code = status_code
     mock_resp.json = MagicMock(return_value=data)
     return mock_resp
 
@@ -91,10 +103,18 @@ class TestLookupDomainSuccess:
         mock_client.__aexit__ = AsyncMock(return_value=None)
         mock_client.get = mock_get
 
+        # Mock session.execute for the customer-tenant check
+        mock_customer = MagicMock()
+        mock_customer.id = 1
+        mock_customer.tenant_id = 42
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_customer)
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
         with patch("services.enrichment_service.settings") as mock_settings, \
-             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client) as mock_client_cls:
+             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
             mock_settings.clearbit_api_key = "test-key"
-            result = await service.lookup(domain="stripe.com", customer_id=1)
+            result = await service.lookup(domain="stripe.com", customer_id=1, tenant_id=42)
 
         assert result["name"] == "Stripe"
         assert result["domain"] == "stripe.com"
@@ -122,10 +142,17 @@ class TestLookupDomainSuccess:
         mock_client.__aexit__ = AsyncMock(return_value=None)
         mock_client.get = mock_get
 
+        mock_customer = MagicMock()
+        mock_customer.id = 1
+        mock_customer.tenant_id = 1
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_customer)
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
         with patch("services.enrichment_service.settings") as mock_settings, \
              patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
             mock_settings.clearbit_api_key = "test-key"
-            await service.lookup(domain="acme.com", customer_id=1)
+            await service.lookup(domain="acme.com", customer_id=1, tenant_id=1)
 
         mock_db_session.add.assert_called_once()
         added = mock_db_session.add.call_args[0][0]
@@ -150,10 +177,17 @@ class TestLookupCompanyNameSuccess:
         mock_client.__aexit__ = AsyncMock(return_value=None)
         mock_client.get = mock_get
 
+        mock_customer = MagicMock()
+        mock_customer.id = 1
+        mock_customer.tenant_id = 1
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_customer)
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
         with patch("services.enrichment_service.settings") as mock_settings, \
              patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
             mock_settings.clearbit_api_key = "test-key"
-            result = await service.lookup(company_name="Acme Corp", customer_id=1)
+            result = await service.lookup(company_name="Acme Corp", customer_id=1, tenant_id=1)
 
         call_kwargs = mock_client.get.call_args
         assert call_kwargs.kwargs["params"]["name"] == "Acme Corp"
@@ -161,11 +195,51 @@ class TestLookupCompanyNameSuccess:
 
 
 # ---------------------------------------------------------------------------
+# lookup — cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+class TestLookupCrossTenantIsolation:
+    async def test_customer_from_different_tenant_raises_not_found(self, service, mock_db_session):
+        """Service raises NotFoundException when customer_id belongs to a different tenant."""
+        with patch("services.enrichment_service.settings") as mock_settings:
+            mock_settings.clearbit_api_key = "test-key"
+            # No customer found for this tenant_id + customer_id combination
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none = MagicMock(return_value=None)
+            mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+            with pytest.raises(NotFoundException) as exc_info:
+                await service.lookup(domain="stripe.com", customer_id=1, tenant_id=999)
+            assert "Customer" in exc_info.value.detail
+
+    async def test_lookup_without_tenant_id_skips_tenant_check(self, service, mock_db_session):
+        """When tenant_id is None, no customer lookup is performed."""
+        mock_resp = MagicMock()
+        mock_resp.is_success = True
+        mock_resp.json = MagicMock(return_value={"name": "Stripe", "domain": "stripe.com"})
+        mock_get = AsyncMock(return_value=mock_resp)
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = mock_get
+
+        with patch("services.enrichment_service.settings") as mock_settings, \
+             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
+            mock_settings.clearbit_api_key = "test-key"
+            # tenant_id=None skips the customer lookup — no execute call
+            result = await service.lookup(domain="stripe.com", customer_id=1, tenant_id=None)
+
+        mock_db_session.execute.assert_not_called()
+        assert result["name"] == "Stripe"
+
+
+# ---------------------------------------------------------------------------
 # lookup — HTTP error cases
 # ---------------------------------------------------------------------------
 
 class TestLookupHttpErrors:
-    async def test_http_404_returns_empty_dict(self, service):
+    async def test_http_404_raises_validation_exception(self, service, mock_db_session):
         mock_resp = MagicMock()
         mock_resp.is_success = False
         mock_resp.status_code = 404
@@ -177,13 +251,21 @@ class TestLookupHttpErrors:
         mock_client.__aexit__ = AsyncMock(return_value=None)
         mock_client.get = mock_get
 
+        mock_customer = MagicMock()
+        mock_customer.id = 1
+        mock_customer.tenant_id = 1
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_customer)
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
         with patch("services.enrichment_service.settings") as mock_settings, \
              patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
             mock_settings.clearbit_api_key = "test-key"
-            result = await service.lookup(domain="notfound.example.com", customer_id=1)
-        assert result == {}
+            with pytest.raises(ValidationException) as exc_info:
+                await service.lookup(domain="notfound.example.com", customer_id=1, tenant_id=1)
+        assert "No company found" in exc_info.value.detail
 
-    async def test_http_500_raises_validation_exception(self, service):
+    async def test_http_500_raises_validation_exception(self, service, mock_db_session):
         mock_resp = MagicMock()
         mock_resp.is_success = False
         mock_resp.status_code = 500
@@ -195,14 +277,48 @@ class TestLookupHttpErrors:
         mock_client.__aexit__ = AsyncMock(return_value=None)
         mock_client.get = mock_get
 
+        mock_customer = MagicMock()
+        mock_customer.id = 1
+        mock_customer.tenant_id = 1
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_customer)
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
         with patch("services.enrichment_service.settings") as mock_settings, \
              patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
             mock_settings.clearbit_api_key = "test-key"
             with pytest.raises(ValidationException) as exc_info:
-                await service.lookup(domain="stripe.com", customer_id=1)
+                await service.lookup(domain="stripe.com", customer_id=1, tenant_id=1)
         assert "Clearbit API error" in exc_info.value.detail
 
-    async def test_missing_api_key_raises(self, service):
+    async def test_http_503_raises_validation_exception(self, service, mock_db_session):
+        """Non-500 non-404 errors (e.g. 503) also raise ValidationException."""
+        mock_resp = MagicMock()
+        mock_resp.is_success = False
+        mock_resp.status_code = 503
+        mock_resp.json = MagicMock(return_value={})
+        mock_get = AsyncMock(return_value=mock_resp)
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = mock_get
+
+        mock_customer = MagicMock()
+        mock_customer.id = 1
+        mock_customer.tenant_id = 1
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=mock_customer)
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("services.enrichment_service.settings") as mock_settings, \
+             patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
+            mock_settings.clearbit_api_key = "test-key"
+            with pytest.raises(ValidationException) as exc_info:
+                await service.lookup(domain="stripe.com", customer_id=1, tenant_id=1)
+        assert "Clearbit API error: 503" in exc_info.value.detail
+
+    async def test_missing_api_key_raises(self, service, mock_db_session):
         with patch("services.enrichment_service.settings") as mock_settings:
             mock_settings.clearbit_api_key = None
 
@@ -261,3 +377,7 @@ class TestNormaliseClearbit:
         assert "name" in result
         assert "geo_city" not in result
         assert "metrics_employees" not in result
+
+    def test_empty_input_returns_empty_dict(self, service):
+        """Empty input dict should return empty dict (no keys present)."""
+        assert service._normalise_clearbit({}) == {}

--- a/tests/unit/test_enrichment_service.py
+++ b/tests/unit/test_enrichment_service.py
@@ -32,20 +32,25 @@ def service(mock_db_session):
 class TestLookupArgumentValidation:
     async def test_neither_domain_nor_name_raises(self, service):
         with pytest.raises(ValidationException) as exc_info:
-            await service.lookup(domain=None, company_name=None)
+            await service.lookup(domain=None, company_name=None, customer_id=1)
         assert "exactly one" in exc_info.value.detail
 
     async def test_both_domain_and_name_raises(self, service):
         with pytest.raises(ValidationException) as exc_info:
-            await service.lookup(domain="stripe.com", company_name="Stripe")
+            await service.lookup(domain="stripe.com", company_name="Stripe", customer_id=1)
         assert "exactly one" in exc_info.value.detail
+
+    async def test_missing_customer_id_raises(self, service):
+        with pytest.raises(ValidationException) as exc_info:
+            await service.lookup(domain="stripe.com", customer_id=None)
+        assert "customer_id" in exc_info.value.detail
 
 
 # ---------------------------------------------------------------------------
 # lookup — HTTP client mock factory
 # ---------------------------------------------------------------------------
 
-async def _make_http_response(is_success: bool, data: dict) -> MagicMock:
+def _make_http_response(is_success: bool, data: dict) -> MagicMock:
     """Return a mock httpx response matching httpx 0.28.x sync Response.json()."""
     mock_resp = MagicMock()
     mock_resp.is_success = is_success
@@ -89,7 +94,7 @@ class TestLookupDomainSuccess:
         with patch("services.enrichment_service.settings") as mock_settings, \
              patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client) as mock_client_cls:
             mock_settings.clearbit_api_key = "test-key"
-            result = await service.lookup(domain="stripe.com")
+            result = await service.lookup(domain="stripe.com", customer_id=1)
 
         assert result["name"] == "Stripe"
         assert result["domain"] == "stripe.com"
@@ -120,12 +125,13 @@ class TestLookupDomainSuccess:
         with patch("services.enrichment_service.settings") as mock_settings, \
              patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
             mock_settings.clearbit_api_key = "test-key"
-            await service.lookup(domain="acme.com")
+            await service.lookup(domain="acme.com", customer_id=1)
 
         mock_db_session.add.assert_called_once()
         added = mock_db_session.add.call_args[0][0]
-        assert added.customer_id == 0
+        assert added.customer_id == 1
         assert added.provider == "clearbit"
+        mock_db_session.flush.assert_awaited_once()
         mock_db_session.flush.assert_awaited_once()
 
 
@@ -148,7 +154,7 @@ class TestLookupCompanyNameSuccess:
         with patch("services.enrichment_service.settings") as mock_settings, \
              patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
             mock_settings.clearbit_api_key = "test-key"
-            result = await service.lookup(company_name="Acme Corp")
+            result = await service.lookup(company_name="Acme Corp", customer_id=1)
 
         call_kwargs = mock_client.get.call_args
         assert call_kwargs.kwargs["params"]["name"] == "Acme Corp"
@@ -160,7 +166,7 @@ class TestLookupCompanyNameSuccess:
 # ---------------------------------------------------------------------------
 
 class TestLookupHttpErrors:
-    async def test_http_404_raises_validation_exception(self, service):
+    async def test_http_404_returns_empty_dict(self, service):
         mock_resp = MagicMock()
         mock_resp.is_success = False
         mock_resp.status_code = 404
@@ -175,9 +181,8 @@ class TestLookupHttpErrors:
         with patch("services.enrichment_service.settings") as mock_settings, \
              patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
             mock_settings.clearbit_api_key = "test-key"
-            with pytest.raises(ValidationException) as exc_info:
-                await service.lookup(domain="notfound.example.com")
-        assert "Clearbit API error" in exc_info.value.detail
+            result = await service.lookup(domain="notfound.example.com", customer_id=1)
+        assert result == {}
 
     async def test_http_500_raises_validation_exception(self, service):
         mock_resp = MagicMock()
@@ -195,7 +200,7 @@ class TestLookupHttpErrors:
              patch("services.enrichment_service.httpx.AsyncClient", return_value=mock_client):
             mock_settings.clearbit_api_key = "test-key"
             with pytest.raises(ValidationException) as exc_info:
-                await service.lookup(domain="stripe.com")
+                await service.lookup(domain="stripe.com", customer_id=1)
         assert "Clearbit API error" in exc_info.value.detail
 
     async def test_missing_api_key_raises(self, service):
@@ -203,7 +208,7 @@ class TestLookupHttpErrors:
             mock_settings.clearbit_api_key = None
 
             with pytest.raises(ValidationException) as exc_info:
-                await service.lookup(domain="stripe.com")
+                await service.lookup(domain="stripe.com", customer_id=1)
             assert "not configured" in exc_info.value.detail
 
 


### PR DESCRIPTION
Closes #511

Plan: `.plans/issue-511.md`

This PR was auto-implemented by Claude Code in three stages:

1. **Plan** — Claude wrote a detailed implementation plan to `.plans/issue-511.md`.
2. **Implement** — Claude executed the plan, ran `ruff check src/` + the unit and integration test suites, and iterated until all three were green.
3. **Self-review** — Claude reviewed its own diff against `codereview.md` (the project review checklist) and fixed any rule violations found, re-running the test suite if any changes were made.

PR-time CI (`Dev Agent CI`) re-verifies independently before this PR is mergeable.

Please review before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Company enrichment lookup endpoint (POST) for domain or company name; results normalized and persisted per tenant/customer.
  * Configurable Clearbit integration with timeouts and API key support.

* **Validation & Behavior**
  * Requires customer identifier and enforces exactly one of domain or company name; clear error responses for not-found and API errors.
  * Ensures one enrichment record per tenant/customer.

* **Documentation**
  * Added planning/design doc for the enrichment feature.

* **Tests**
  * Comprehensive unit and router tests covering success, validation, errors, tenancy, and normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yihua-zhuo/agent-job/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->