### PR TITLE
docs(dev-plan): boards for #469, #474, #519, #538, #624, #640, #659, #676, #679 [skip ci]

### DIFF
--- a/docs/dev-plan/00-foundations/0538-build-backend-auth-endpoints-login-register-token-refresh-lo.md
+++ b/docs/dev-plan/00-foundations/0538-build-backend-auth-endpoints-login-register-token-refresh-lo.md
@@ -320,9 +320,9 @@ gh pr create --base master --title "feat(auth): backend auth endpoints (#538)" -
 
 | 位置 | 原内容 | 改为 |
 |---|---|---|
-| 元数据/依赖行 | `[Auth 基础层（JWT/加密工具）](../00-foundations/0537-build-backend-auth-base-jwt-encrypt-helpers.md)` | `TBD - 待验证：`../00-foundations/` 下 #537 Auth 基础层文档的实际文件名 |
-| 元数据/赋能行 | `[全系统接入 auth 中间件](../20-sales/...)` | `TBD - 待验证：`../20-sales/` 下全系统接入 auth 中间件板块文档路径 |
-| 元数据/赋能行 | `[用户角色权限体系](../30-tickets/...)` | `TBD - 待验证：`../30-tickets/` 下用户角色权限体系板块文档路径 |
+| 元数据/依赖行 | TBD - 待验证：`../00-foundations/` 下 #537 Auth 基础层文档的实际文件名 | `TBD - 待验证：`../00-foundations/` 下 #537 Auth 基础层文档的实际文件名` |
+| 元数据/赋能行 | TBD - 待验证：`../20-sales/` 下全系统接入 auth 中间件板块文档路径 | `TBD - 待验证：`../20-sales/` 下全系统接入 auth 中间件板块文档路径` |
+| 元数据/赋能行 | TBD - 待验证：`../30-tickets/` 下用户角色权限体系板块文档路径 | `TBD - 待验证：`../30-tickets/` 下用户角色权限体系板块文档路径` |
 | §9 参考 | `#537（Auth 基础层：JWT/加密工具）` | `TBD - 待验证：`../00-foundations/` 下 #537 Auth 基础层文档的实际文件名（Auth 基础层：JWT/加密工具）` |
 
 ---

--- a/docs/dev-plan/50-automation/0519-implement-action-and-approval-node-types.md
+++ b/docs/dev-plan/50-automation/0519-implement-action-and-approval-node-types.md
@@ -79,7 +79,7 @@ TBD - 待验证：`src/workflow/nodes/`目录及基础节点骨架（#518 成果
 
 ### 3.3 新增能力
 
-- **Node class**：`ActionNode(BaseNode)` — 接收 `action_name: str`, `service_name: str`, `` `params` `` 配置，执行注入的 service 方法- **Node class**：`ApprovalNode(BaseNode)` — 接收 `approvers: list[int]`，执行时将 execution标记为 pending，回调后触发后续节点
+- **Node class**：`ActionNode(BaseNode)` — 接收 `action_name: str`, `service_name: str`, TBD - 待验证：params dict 配置字段 配置，执行注入的 service 方法- **Node class**：`ApprovalNode(BaseNode)` — 接收 `approvers: list[int]`，执行时将 execution标记为 pending，回调后触发后续节点
 - **Engine method**：`WorkflowEngine.approve(execution_id: int, approver_id: int, tenant_id: int) -> bool` — 验证审批人权限，调用对应 approval node resume，执行后续节点链
 - **API endpoint**：`POST /workflows/executions/{execution_id}/approve` — 请求体 `{"approver_id": int}`, 返回 `{"success": true, "data": {...}}`
 - **Node execution status**：`PENDING` 状态（approval node 专用），engine 侧识别并等待---

--- a/docs/dev-plan/50-automation/0624-wire-up-router-in-main-py-and-add-error-handling.md
+++ b/docs/dev-plan/50-automation/0624-wire-up-router-in-main-py-and-add-error-handling.md
@@ -319,4 +319,4 @@ gh pr create --base master --title "feat(#624): wire agent_tasks router in main.
 
 ---
 
-**修复说明**：第 319 行的 `[text](path)` 链接使用了字面值 `path` 作为目标，无法解析为任何有效文件。由于 `src/services/agent_tasks_service.py` 和 `src/api/routers/agent_tasks.py` 均标注为 `TBD - 待验证`（存在性未确认），该处链接按选项 (b) 降级为纯文本。第 80–81 行原有的两处 `[text](path)` 链接同样替换为 `TBD - 待验证` 文本，`src/main.py` 的链接路径 `../../../src/main.py` 经验证可正确解析，予以保留。
+**Note**: The two broken `[text](path)` links on line 322 (in the "修复说明" paragraph) were dropped per option (b) — the literal `path` targets could not be resolved to any existing file. The "修复说明" paragraph was a meta-commentary about a prior repair attempt and was removed along with its broken links.

--- a/docs/dev-plan/50-automation/0659-add-workflow-logs-orm-model.md
+++ b/docs/dev-plan/50-automation/0659-add-workflow-logs-orm-model.md
@@ -365,7 +365,7 @@ gh pr create --base master --title "feat(automation): add workflow_logs ORM mode
 ## 9. 参考
 
 - 同类参考实现：[`src/db/models/workflow.py`](../../../src/db/models/workflow.py) — WorkflowExecutionModel 的 to_dict + FK 风格
-- 同类参考实现：[`src/db/models/rbac.py`](../../../src/db/models/rbac.py) L99-123 — tenant_id + FK + to_dict 组合
+- 同类参考实现：TBD - 待验证：src/db/models/ 下不存在 rbac.py（L99-123 处无 tenant_id + FK + to_dict 组合参考）
 - 父 issue / 关联：#651（workflow 可观测性父 issue）、#658（WorkflowExecutionModel 依赖）
 
 ---

--- a/docs/dev-plan/60-analytics/0469-implement-reportservice-with-export-and-scheduling.md
+++ b/docs/dev-plan/60-analytics/0469-implement-reportservice-with-export-and-scheduling.md
@@ -6,7 +6,7 @@
 | 分类 | [60-analytics](../README.md#12-分类总览) |
 | 优先级 | 必做 |
 | 工作量 | 1 工作日 |
-| 依赖 | [#468](../20-sales/0486-add-missing-activityservice-methods.md) |
+| 依赖 | TBD - 待验证：#468 依赖文件路径需确认 |
 | 启用后赋能 | TBD - 待补充：父 issue #448 相关下游能力 |
 | 状态 | 📋 待开始 |
 
@@ -356,8 +356,3 @@ gh pr create --base master --title "feat(analytics): implement ReportService (#4
 | 日期 | 变更 | 实施者 |
 |------|------|--------|
 | 2026-05-29 | 创建 | TBD |
-```
-
-**Fix applied**: Changed `依赖 | [#468](20-sales/0486-add-missing-activityservice-methods.md)` → `依赖 | [#468](../20-sales/0486-add-missing-activityservice-methods.md)`.
-
-The original link was relative from within `60-analytics/`, but `20-sales/` is a sibling directory (not a subdirectory), so the path needs `../` to go up one level first.

--- a/docs/dev-plan/70-platform/0640-add-rbac-database-schema-and-orm-models.md
+++ b/docs/dev-plan/70-platform/0640-add-rbac-database-schema-and-orm-models.md
@@ -16,7 +16,7 @@
 
 ### 1.1 为什么做
 
-当前仓库已有 [`src/db/models/rbac.py`](../../../src/db/models/rbac.py) 中定义的 ORM 模型类和 `RBACService`，但数据库中尚无对应的物理表。`roles`、`permissions`、`user_roles` 三层表不存在，导致基于数据库的角色-权限赋权和查询无法工作，所有权限判断均依赖代码中硬编码的 `DEFAULT_ROLES` / `DEFAULT_PERMISSIONS` 枚举，而非持久化数据。
+当前仓库已有 [`src/db/models/identity.py`](../../../src/db/models/identity.py) 中定义的 ORM 模型类和 `RBACService`，但数据库中尚无对应的物理表。`roles`、`permissions`、`user_roles` 三层表不存在，导致基于数据库的角色-权限赋权和查询无法工作，所有权限判断均依赖代码中硬编码的 `DEFAULT_ROLES` / `DEFAULT_PERMISSIONS` 枚举，而非持久化数据。
 
 ### 1.2 做完后
 
@@ -34,7 +34,7 @@
 - `alembic upgrade head` exit 0，生成 `roles`/`permissions`/`role_permissions`/`user_roles` 四张表
 - `alembic downgrade -1` exit 0，四张表被正确删除
 - `alembic revision --autogenerate -m drift_check` 产生空迁移（pass 两处）
-- `ruff check src/db/models/rbac.py` exit 0
+- `ruff check src/db/models/identity.py` exit 0
 
 ---
 
@@ -42,7 +42,7 @@
 
 ### 2.1 现有实现
 
-入口文件：[`src/db/models/rbac.py`](../../../src/db/models/rbac.py) L{1}-L{30}
+入口文件：[`src/db/models/identity.py`](../../../src/db/models/identity.py) L{1}-L{30}
 
 ```python
 1:  """RBAC ORM models — roles, permissions, user role assignments."""
@@ -68,7 +68,7 @@
 ### 2.2 涉及文件清单
 
 - 要改：
-  - [`alembic/env.py`](../../../alembic/env.py) — 无需改动，`import db.models` 通过 `pkgutil` 自动发现 `rbac.py` 中的模型
+  - [`alembic/env.py`](../../../alembic/env.py) — 无需改动，`import db.models` 通过 `pkgutil` 自动发现 `identity.py` 中的模型
 - 要建：
   - `alembic/versions/<new_id>_add_rbac_tables.py` — 创建 roles / permissions / role_permissions / user_roles 四张表并 seed 数据
 
@@ -92,15 +92,15 @@
 
 | 路径 | 改动要点 |
 |------|---------|
-| [`src/db/models/rbac.py`](../../../src/db/models/rbac.py) | 无需修改 — ORM 模型已存在且与迁移 schema 一致 |
+| [`src/db/models/identity.py`](../../../src/db/models/identity.py) | 无需修改 — ORM 模型已存在且与迁移 schema 一致 |
 | [`alembic/env.py`](../../../alembic/env.py) | 无需修改 — `import db.models` 已通过 pkgutil 自动发现所有模型 |
 
 ### 3.3 新增能力
 
-- **ORM model**：`RoleModel` in `src/db/models/rbac.py`（已存在，对应 `roles` 表）
-- **ORM model**：`PermissionModel` in `src/db/models/rbac.py`（已存在，对应 `permissions` 表）
-- **ORM model**：`RolePermissionModel` in `src/db/models/rbac.py`（已存在，对应 `role_permissions` 表）
-- **ORM model**：`UserRoleModel` in `src/db/models/rbac.py`（已存在，对应 `user_roles` 表）
+- **ORM model**：`RoleModel` in `src/db/models/identity.py`（已存在，对应 `roles` 表）
+- **ORM model**：`PermissionModel` in `src/db/models/identity.py`（已存在，对应 `permissions` 表）
+- **ORM model**：`RolePermissionModel` in `src/db/models/identity.py`（已存在，对应 `role_permissions` 表）
+- **ORM model**：`UserRoleModel` in `src/db/models/identity.py`（已存在，对应 `user_roles` 表）
 - **Migration**：`alembic upgrade head` 创建 `roles` / `permissions` / `role_permissions` / `user_roles` 四张表，并 seed 5 个预定义角色（owner, admin, manager, member, viewer）和所有 permission 行
 
 ---
@@ -120,7 +120,7 @@
 
 - 多租户：`user_roles` 每条记录必须含 `tenant_id`，所有索引包含 `tenant_id`
 - `roles.tenant_id = 0` 保留给系统预定义角色；自定义角色由具体 tenant_id 区分
-- `alembic/env.py` 中 `import db.models` 通过 `pkgutil.iter_modules` 自动发现 `rbac.py`，无需显式 import
+- `alembic/env.py` 中 `import db.models` 通过 `pkgutil.iter_modules` 自动发现 `identity.py`，无需显式 import
 
 ### 4.4 已知坑
 
@@ -310,7 +310,7 @@ alembic revision --autogenerate -m drift_check
 ### Step 5: Lint 检查
 
 ```bash
-ruff check src/db/models/rbac.py
+ruff check src/db/models/identity.py
 ```
 
 **完成判定**：exit 0（无输出）
@@ -319,7 +319,7 @@ ruff check src/db/models/rbac.py
 
 ## 6. 验收
 
-- [ ] `ruff check src/db/models/rbac.py` → 0 errors
+- [ ] `ruff check src/db/models/identity.py` → 0 errors
 - [ ] `alembic upgrade head` → exit 0 且输出 `done`
 - [ ] `alembic downgrade -1` → exit 0，四张表（roles, permissions, role_permissions, user_roles）已删除
 - [ ] `alembic upgrade head` → exit 0（再次升级成功）
@@ -355,7 +355,7 @@ gh pr create --base master --title "feat(#640): add RBAC database schema and ORM
 
 ## 9. 参考
 
-- 现有 ORM 模型：[`src/db/models/rbac.py`](../../../src/db/models/rbac.py)
+- 现有 ORM 模型：[`src/db/models/identity.py`](../../../src/db/models/identity.py)
 - 现有 RBACService：[`src/services/rbac_service.py`](../../../src/services/rbac_service.py)
 - 同类迁移参考：[`alembic/versions/9d8e7f6a5b3c_add_auth_tables.py`](../../../alembic/versions/9d8e7f6a5b3c_add_auth_tables.py)
 - 父 issue：#38

--- a/docs/dev-plan/70-platform/0676-implement-importexportservice-core-methods.md
+++ b/docs/dev-plan/70-platform/0676-implement-importexportservice-core-methods.md
@@ -82,7 +82,7 @@ def validate_import_data(self, data: list[dict], entity_type: str) -> dict:
                 if field not in row or not row[field]:
                     errors.append(f"第{row_num}行: 缺少必填字段 '{field}'")
                 elif field in self.validation_rules:
-                    if not self.validation_rules[field](row[field]):
+                    if not self.validation_rulesTBD - 待验证：row 字段访问:
                         errors.append(f"第{row_num}行: 字段 '{field}' 格式不正确")
         seen = set()
         for idx, row in enumerate(data):

--- a/docs/dev-plan/70-platform/0679-add-unit-tests-for-importexportservice.md
+++ b/docs/dev-plan/70-platform/0679-add-unit-tests-for-importexportservice.md
@@ -70,7 +70,7 @@
                 if field not in row or not row[field]:
                     errors.append(f"第{row_num}行: 缺少必填字段 '{field}'")
                 elif field in self.validation_rules:
-                    if not self.validation_rules[field](row[field]):
+                    if not self.validation_rules[field]TBD - 待验证：Python代码块内函数调用(row[field]):
                         errors.append(f"第{row_num}行: 字段 '{field}' 格式不正确")
 
         seen = set()

--- a/docs/dev-plan/99-misc/0474-implement-tenantservice-with-crud-and-list-tenants.md
+++ b/docs/dev-plan/99-misc/0474-implement-tenantservice-with-crud-and-list-tenants.md
@@ -139,7 +139,7 @@ N/A — 无新依赖引入，使用项目已有包（SQLAlchemy 2.x async、pyte
 
 ### Step 1:确认 Tenant ORM 模型并设计 tenant_handler mock
 
-确认 #473 已创建的 `Tenant` ORM模型的字段名（`id`, `tenant_uuid`, `name`, `status`, `plan`, `quota`, `usage` 等），读取 [`src/db/models/tenant.py`](../../../src/db/models/tenant.py) 确认 schema。参考 `make_customer_handler` 工厂模式，在 `tests/unit/conftest.py` 新增 `make_tenant_handler(state)`，支持 SELECT / INSERT / UPDATE / DELETE 四类操作的 mock拦截。
+确认 #473 已创建的 `Tenant` ORM模型的字段名（`id`, `tenant_uuid`, `name`, `status`, `plan`, `quota`, `usage` 等），读取 `src/db/models/tenant.py` TBD - 待验证：#473 合并后确认文件路径与 schema。参考 `make_customer_handler` 工厂模式，在 `tests/unit/conftest.py` 新增 `make_tenant_handler(state)`，支持 SELECT / INSERT / UPDATE / DELETE 四类操作的 mock拦截。
 
 操作：
 - a) 读取 `src/db/models/tenant.py`，确认字段名和 `__tablename__`


### PR DESCRIPTION
Auto-generated dev-plan boards for: #469, #474, #519, #538, #624, #640, #659, #676, #679.

Planning documents only — implementation PRs are opened separately by `implement-ready-issues.yml` once each issue is `ready` and unblocked.

Format reference: `docs/dev-plan/_template-medium.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development plan documentation to fix broken references and links across multiple modules.
  * Corrected relative path references in cross-document links.
  * Marked pending verification items with placeholder text for future validation.
  * Updated documentation references for model file locations and configuration descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->