### PR TITLE
docs(dev-plan): boards for #519, #624 [skip ci]

### DIFF
--- a/docs/dev-plan/50-automation/0519-implement-action-and-approval-node-types.md
+++ b/docs/dev-plan/50-automation/0519-implement-action-and-approval-node-types.md
@@ -130,7 +130,7 @@ TBD - 待验证：`src/workflow/nodes/`目录及基础节点骨架（#518 成果
 操作：
 - a) 定义 `class ActionNode(BaseNode):`
 - b) `config_schema`包含 `action_name: str`, `service_name: str`, `params: dict`
-- c) `validate_config()`校验 service 在 registry 中存在- d) `execute(ctx)` 调用 `ctx.services[TBD - 待验证：service_name 配置字段](**params)` 并返回 `NodeResult(status="completed", output={...})`
+- c) `validate_config()`校验 service 在 registry 中存在- d) `execute(ctx)` 调用 `ctx.services`TBD - 待验证：service_name 配置字段 并返回 `NodeResult(status="completed", output={...})`
 
 示例代码：
 

--- a/docs/dev-plan/50-automation/0624-wire-up-router-in-main-py-and-add-error-handling.md
+++ b/docs/dev-plan/50-automation/0624-wire-up-router-in-main-py-and-add-error-handling.md
@@ -319,4 +319,4 @@ gh pr create --base master --title "feat(#624): wire agent_tasks router in main.
 
 ---
 
-**Note**: The two broken `[text](path)` links on line 322 (in the "修复说明" paragraph) were dropped per option (b) — the literal `path` targets could not be resolved to any existing file. The "修复说明" paragraph was a meta-commentary about a prior repair attempt and was removed along with its broken links.
+**Note**: The two broken `TBD - 待验证：placeholder path（无可解析目标）` links on line 322 (in the "修复说明" paragraph) were dropped per option (b) — the literal `path` targets could not be resolved to any existing file. The "修复说明" paragraph was a meta-commentary about a prior repair attempt and was removed along with its broken links.


### PR DESCRIPTION
Auto-generated dev-plan boards for: #519, #624.

Planning documents only — implementation PRs are opened separately by `implement-ready-issues.yml` once each issue is `ready` and unblocked.

Format reference: `docs/dev-plan/_template-medium.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified roadmap notes and removed an outdated placeholder reference from the development plan.
  * Updated changelog wording to better identify removed broken links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->